### PR TITLE
Installation script for gips & edit for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # GIPS
 
-See the [GIPS](http://gipit.github.io/gips/) for documentation.
+See http://gipit.github.io/gips/ for documentation, but know it is not
+necessarily current.
+
+## Installation
+
+After cloning this git repo & changing to its directory, run `install.sh`,
+which only supports recent versions of Ubuntu.  It will use `sudo` to install
+system packages, and may ask for authentication accordingly.  It runs apt-get,
+which may prompt you for confirmation of its actions.
 
 #### Authors and Contributors
 The following have been authors or contributers to GIPS

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ echo === install system deps ===
 
 # TODO I doubt *ALL* the boost libs are needed and there are MANY of them;
 # would be great to reduce the bulk
-sudo apt-get install g++ gfortran swig \
+sudo apt-get install virtualenv python g++ gfortran swig \
                      libboost-all-dev libfreetype6-dev libgnutls-dev \
                      libatlas-base-dev libgdal-dev libgdal1-dev gdal-bin \
                      python-pip python-numpy python-scipy python-gdal 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+set -e
+
+# this script needs to run in the clone dir
+git remote get-url origin | grep Applied-GeoSolutions/gips.git -q
+test -d .git
+
+echo === install system deps ===
+# TODO are these needed?
+# innstall UbuntuGIS repository
+# sudo apt-get install python-software-properties
+# sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
+# sudo apt-get update
+
+# TODO I doubt *ALL* the boost libs are needed and there are MANY of them;
+# would be great to reduce the bulk
+sudo apt-get install g++ gfortran swig \
+                     libboost-all-dev libfreetype6-dev libgnutls-dev \
+                     libatlas-base-dev libgdal-dev libgdal1-dev gdal-bin \
+                     python-pip python-numpy python-scipy python-gdal 
+
+echo === clone source repo and setup virtualenv ===
+virtualenv ve --system-site-packages
+. ve/bin/activate
+
+echo === install untracked dependencies ===
+pip install six==1.9.0
+# gippy has to be done this way because gippy stopped being tracked in pypi
+pip install 'https://github.com/Applied-GeoSolutions/gippy/tarball/v0.3.x#egg=gippy-0.3.8-'`date +%Y%m%d`
+
+echo === install GIPS itself ===
+# TODO --process-dependency-links is deprecated
+pip install --process-dependency-links -e .
+
+# check install: if this exits 0, install probably succeeded
+gips_config print &>/dev/null
+echo "Install complete."


### PR DESCRIPTION
So this uses `pip` and `virtualenv` instead of `setup.py develop` etc, but I figure any install method that is correct is better than none.  Also it does some safety checks when it runs and stops on error immediately (thanks to `set -e`).

The various `gips_*` executables run successfully after I used this install script on my own machine, but there could still be problems; I figure I can iterate as I go if I discover something's wrong/missing. 

