### PR TITLE
fix #61, fix(?) #46, improve system test harness

### DIFF
--- a/gips/data/core.py
+++ b/gips/data/core.py
@@ -179,6 +179,7 @@ class Asset(object):
         '': {'description': ''},
     }
     # dictionary of assets
+    # TODO - support regular expressions for patterns
     _assets = {
         '': {
             'pattern': '*',

--- a/gips/test/landsat.sh
+++ b/gips/test/landsat.sh
@@ -8,7 +8,6 @@ DATES="-d 2012-256"
 
 ARGS="-s $GIPSTESTPATH/NHseacoast.shp $DATES -v 4 -p acca ref-toa ndvi-toa rad-toa"
 
-gips_info landsat
 gips_inventory landsat $ARGS
 gips_process landsat $ARGS
 

--- a/gips/test/sys/expected/landsat.py
+++ b/gips/test/sys/expected/landsat.py
@@ -90,6 +90,7 @@ SENSORS\x1b[0m
 """}
 
 t_process = {
+    'compare_stderr': False,
     'updated': {'landsat/tiles/012030/2015352': None},
     'created': {
         'landsat/tiles/012030/2015352/012030_2015352_LC8_acca.tif': -1532119925,

--- a/gips/test/sys/expected/landsat.py
+++ b/gips/test/sys/expected/landsat.py
@@ -61,3 +61,43 @@ Standard Products
                  toa: use top of the atmosphere reflectance
    wtemp       Water temperature (atmospherically correct) - valid for water only
 """}
+
+t_inventory = { 'stdout': """\x1b[1mGIPS Data Inventory (v0.8.2)\x1b[0m
+Retrieving inventory for site NHseacoast-0
+fname
+LC80120302015352LGN00.tar.gz
+DN asset
+
+\x1b[1mAsset Coverage for site NHseacoast-0\x1b[0m
+\x1b[1m
+Tile Coverage
+\x1b[4m  Tile      % Coverage   % Tile Used\x1b[0m
+  012030      100.0%        6.7%
+  013030        2.4%        0.2%
+
+\x1b[1m\x1b[4m    DATE        DN        SR     Product  \x1b[0m
+\x1b[1m2015        
+\x1b[0m    352       100.0%             
+
+
+1 files on 1 dates
+\x1b[1m
+SENSORS\x1b[0m
+\x1b[35mLC8: Landsat 8\x1b[0m
+\x1b[31mLC8SR: Landsat 8 Surface Reflectance\x1b[0m
+\x1b[32mLE7: Landsat 7\x1b[0m
+\x1b[34mLT5: Landsat 5\x1b[0m
+"""}
+
+t_process = {
+    'updated': {'landsat/tiles/012030/2015352': None},
+    'created': {
+        'landsat/tiles/012030/2015352/012030_2015352_LC8_acca.tif': -1532119925,
+        'landsat/tiles/012030/2015352/012030_2015352_LC8_bqashadow.tif': -1566662956,
+        'landsat/tiles/012030/2015352/012030_2015352_LC8_ndvi-toa.tif': -204896503,
+        'landsat/tiles/012030/2015352/012030_2015352_LC8_rad-toa.tif': 1658217796,
+        'landsat/tiles/012030/2015352/012030_2015352_LC8_ref-toa.tif': -1766137404,
+        'landsat/tiles/012030/2015352/LC80120302015352LGN00.tar.gz.index': 1896263933,
+        'landsat/tiles/012030/2015352/LC80120302015352LGN00_MTL.txt': 2084350553,
+    }
+}

--- a/gips/test/sys/expected/landsat.py
+++ b/gips/test/sys/expected/landsat.py
@@ -127,10 +127,26 @@ t_project_no_warp = {
     }
 }
 
+# TODO this bug rearing its ugly head again?
+# See https://github.com/Applied-GeoSolutions/gips/issues/54
+t_tiles = { 'created': {'012030': None}}
+
+t_tiles_copy = {
+    'compare_stderr': False,
+    'created': {
+        '012030': None,
+	'012030/012030_2015352_LC8_acca.tif': 1593997289,
+	'012030/012030_2015352_LC8_bqashadow.tif': -116702962,
+	'012030/012030_2015352_LC8_ndvi-toa.tif': -1923562909,
+	'012030/012030_2015352_LC8_rad-toa.tif': 525640715,
+	'012030/012030_2015352_LC8_ref-toa.tif': -1287648712,
+    }
+}
+
 t_stats = { 'created': {
     'acca_stats.txt': -789655715,
     'bqashadow_stats.txt': 1501756012,
     'ndvi-toa_stats.txt': -77721729,
     'rad-toa_stats.txt': 1664250177,
-    'ref-toa_stats.txt': 2007199405
+    'ref-toa_stats.txt': 2007199405,
 }}

--- a/gips/test/sys/expected/landsat.py
+++ b/gips/test/sys/expected/landsat.py
@@ -102,3 +102,35 @@ t_process = {
         'landsat/tiles/012030/2015352/LC80120302015352LGN00_MTL.txt': 2084350553,
     }
 }
+
+t_project = {
+    'compare_stderr': False,
+    'created': {
+        '0': None,
+        '0/2015352_LC8_acca.tif': -1824905460,
+        '0/2015352_LC8_bqashadow.tif': 1603304372,
+        '0/2015352_LC8_ndvi-toa.tif': 844246796,
+        '0/2015352_LC8_rad-toa.tif': -317896577,
+        '0/2015352_LC8_ref-toa.tif': -1496156246,
+    }
+}
+
+t_project_no_warp = {
+    'compare_stderr': False,
+    'created': {
+        '0': None,
+        '0/2015352_LC8_acca.tif': 1288527028,
+        '0/2015352_LC8_bqashadow.tif': -2134364541,
+        '0/2015352_LC8_ndvi-toa.tif': 1466287813,
+        '0/2015352_LC8_rad-toa.tif': 1618019596,
+        '0/2015352_LC8_ref-toa.tif': -614392204,
+    }
+}
+
+t_stats = { 'created': {
+    'acca_stats.txt': -789655715,
+    'bqashadow_stats.txt': 1501756012,
+    'ndvi-toa_stats.txt': -77721729,
+    'rad-toa_stats.txt': 1664250177,
+    'ref-toa_stats.txt': 2007199405
+}}

--- a/gips/test/sys/expected/landsat.py
+++ b/gips/test/sys/expected/landsat.py
@@ -1,0 +1,63 @@
+"""Known-good outcomes for tests, mostly stdout and created files."""
+
+# trailing whitespace and other junk characters are in current output
+t_info = { 'stdout':  """\x1b[1mGIPS Data Repositories (v0.8.2)\x1b[0m
+\x1b[1m
+Landsat Products v0.9.0\x1b[0m
+  Optional qualifiers listed below each product.
+  Specify by appending '-option' to product (e.g., ref-toa)
+\x1b[1m
+Index Products
+\x1b[0m   bi          Brightness Index                        
+                 toa: use top of the atmosphere reflectance
+   evi         Enhanced Vegetation Index               
+                 toa: use top of the atmosphere reflectance
+   lswi        Land Surface Water Index                
+                 toa: use top of the atmosphere reflectance
+   msavi2      Modified Soil-Adjusted Vegetation Index (revised)
+                 toa: use top of the atmosphere reflectance
+   ndsi        Normalized Difference Snow Index        
+                 toa: use top of the atmosphere reflectance
+   ndvi        Normalized Difference Vegetation Index  
+                 toa: use top of the atmosphere reflectance
+   ndwi        Normalized Difference Water Index       
+                 toa: use top of the atmosphere reflectance
+   satvi       Soil-Adjusted Total Vegetation Index    
+                 toa: use top of the atmosphere reflectance
+\x1b[1m
+LC8SR Products
+\x1b[0m   ndvi8sr     Normalized Difference Vegetation from LC8SR
+\x1b[1m
+Tillage Products
+\x1b[0m   crc         Crop Residue Cover                      
+                 toa: use top of the atmosphere reflectance
+   isti        Inverse Standard Tillage Index          
+                 toa: use top of the atmosphere reflectance
+   ndti        Normalized Difference Tillage Index     
+                 toa: use top of the atmosphere reflectance
+   sti         Standard Tillage Index                  
+                 toa: use top of the atmosphere reflectance
+\x1b[1m
+Standard Products
+\x1b[0m   acca        Automated Cloud Cover Assessment        
+                 X: erosion kernel diameter in pixels (default: 5)
+                 Y: dilation kernel diameter in pixels (default: 10)
+                 Z: cloud height in meters (default: 4000)
+   bqa         LC8 band quality                        
+   bqashadow   LC8 QA + Shadow Smear                   
+                 X: erosion kernel diameter in pixels (default: 5)
+                 Y: dilation kernel diameter in pixels (default: 10)
+                 Z: cloud height in meters (default: 4000)
+   dn          Raw digital numbers                     
+   fmask       Fmask cloud cover                       
+   landmask    Land mask from LC8SR                    
+   rad         Surface-leaving radiance                
+                 toa: use top of the atmosphere reflectance
+   ref         Surface reflectance                     
+                 toa: use top of the atmosphere reflectance
+   tcap        Tassled cap transformation              
+   temp        Brightness (apparent) temperature       
+   volref      Volumetric water reflectance - valid for water only
+                 toa: use top of the atmosphere reflectance
+   wtemp       Water temperature (atmospherically correct) - valid for water only
+"""}

--- a/gips/test/sys/expected/repo_src_alteration.py
+++ b/gips/test/sys/expected/repo_src_alteration.py
@@ -16,6 +16,7 @@ t_landsat_inv_fetch = {
     'created': {
         'landsat/tiles/012030': None,
         'landsat/tiles/012030/2015352': None,
-        'landsat/tiles/012030/2015352/LC80120302015352LGN00.tar.gz': 725162296,
+        'landsat/tiles/012030/2015352/LC80120302015352LGN00.tar.gz':
+            'I cannot be right, see test for details',
     },
 }

--- a/gips/test/sys/expected/repo_src_alteration.py
+++ b/gips/test/sys/expected/repo_src_alteration.py
@@ -10,3 +10,12 @@ t_modis_inv_fetch = {
     },
 }
 
+
+t_landsat_inv_fetch = {
+    'updated': {'landsat/stage': None, 'landsat/tiles': None},
+    'created': {
+        'landsat/tiles/012030': None,
+        'landsat/tiles/012030/2015352': None,
+        'landsat/tiles/012030/2015352/LC80120302015352LGN00.tar.gz': 725162296,
+    },
+}

--- a/gips/test/sys/t_landsat.py
+++ b/gips/test/sys/t_landsat.py
@@ -42,6 +42,35 @@ def t_inventory(setup_landsat_data, repo_env, expected):
 @slow
 def t_process(setup_landsat_data, repo_env, expected):
     """Test gips_process on landsat data."""
-    PROCESS_ARGS = STD_ARGS + product_args
-    actual = repo_env.run('gips_process', *PROCESS_ARGS)
+    args = STD_ARGS + product_args
+    actual = repo_env.run('gips_process', *args)
+    assert expected == actual
+
+
+def t_project(setup_landsat_data, clean_repo_env, output_tfe, expected):
+    """Test gips_project landsat with warping."""
+    args = STD_ARGS + product_args + ('--res', '30', '30', '--outdir', OUTPUT_DIR, '--notld')
+    actual = output_tfe.run('gips_project', *args)
+    assert expected == actual
+
+
+def t_project_no_warp(setup_landsat_data, clean_repo_env, output_tfe, expected):
+    """Test gips_project modis without warping."""
+    args = STD_ARGS + product_args + ('--outdir', OUTPUT_DIR, '--notld')
+    actual = output_tfe.run('gips_project', *args)
+    assert expected == actual
+
+
+def t_stats(setup_landsat_data, clean_repo_env, output_tfe, expected):
+    """Test gips_stats on projected files."""
+    # generate data needed for stats computation
+    args = STD_ARGS + product_args + ('--res', '30', '30', '--outdir', OUTPUT_DIR, '--notld')
+    prep_run = output_tfe.run('gips_project', *args)
+    assert prep_run.exit_status == 0 # confirm it worked; not really in the test
+
+    # compute stats
+    gtfe = GipsTestFileEnv(OUTPUT_DIR, start_clear=False)
+    actual = gtfe.run('gips_stats', OUTPUT_DIR)
+
+    # check for correct stats content
     assert expected == actual

--- a/gips/test/sys/t_landsat.py
+++ b/gips/test/sys/t_landsat.py
@@ -1,11 +1,49 @@
 import logging
 
+import envoy
 import pytest
 
 from .util import *
+
+logger = logging.getLogger(__name__)
+
+# changing this will require changes in expected/
+STD_ARGS = ('landsat', '-s', NH_SHP_PATH, '-d', '2015-352', '-v', '4')
+
+product_args = tuple('-p acca bqashadow ref-toa ndvi-toa rad-toa'.split())
+
+@pytest.fixture
+def setup_landsat_data(pytestconfig):
+    """Use gips_inventory to ensure presence of MODIS data in the data repo."""
+    driver = 'landsat'
+    if not pytestconfig.getoption('setup_repo'):
+        logger.info("Skipping repo setup per lack of option.")
+        return
+    cmd_str = 'gips_inventory ' + ' '.join(STD_ARGS) + ' --fetch'
+    logger.info("Downloading data via `{}`".format(cmd_str))
+    outcome = envoy.run(cmd_str)
+    logger.info("{} data download complete.".format(driver))
+    if outcome.status_code != 0:
+        raise RuntimeError("{} data setup via `gips_inventory` failed".format(driver),
+                           outcome.std_out, outcome.std_err, outcome)
 
 
 def t_info(repo_env, expected):
     """Test `gips_info modis` and confirm recorded output is given."""
     actual = repo_env.run('gips_info', 'landsat')
     assert expected == actual
+
+
+def t_inventory(setup_landsat_data, repo_env, expected):
+    """Test `gips_inventory` to confirm it notices the emplaced data file."""
+    actual = repo_env.run('gips_inventory', *STD_ARGS)
+    assert expected == actual
+
+@slow
+def t_process(setup_landsat_data, repo_env, expected):
+    """Test gips_process on landsat data."""
+    PROCESS_ARGS = STD_ARGS + product_args
+    actual = repo_env.run('gips_process', *PROCESS_ARGS)
+    # can't use `expected == actual`; it emits nondeterministic strings on stderr
+    # TODO make it not do that for normal operations ^^^
+    assert expected.created == actual.created

--- a/gips/test/sys/t_landsat.py
+++ b/gips/test/sys/t_landsat.py
@@ -1,0 +1,11 @@
+import logging
+
+import pytest
+
+from .util import *
+
+
+def t_info(repo_env, expected):
+    """Test `gips_info modis` and confirm recorded output is given."""
+    actual = repo_env.run('gips_info', 'landsat')
+    assert expected == actual

--- a/gips/test/sys/t_landsat.py
+++ b/gips/test/sys/t_landsat.py
@@ -44,6 +44,4 @@ def t_process(setup_landsat_data, repo_env, expected):
     """Test gips_process on landsat data."""
     PROCESS_ARGS = STD_ARGS + product_args
     actual = repo_env.run('gips_process', *PROCESS_ARGS)
-    # can't use `expected == actual`; it emits nondeterministic strings on stderr
-    # TODO make it not do that for normal operations ^^^
-    assert expected.created == actual.created
+    assert expected == actual

--- a/gips/test/sys/t_modis.py
+++ b/gips/test/sys/t_modis.py
@@ -7,9 +7,8 @@ from .util import *
 
 logger = logging.getLogger(__name__)
 
-# changing this will require changes in .data
-STD_ARGS       = ('modis', '-s', NH_SHP_PATH,
-                  '-d', '2012-12-01,2012-12-03', '-v', '4')
+# changing this will require changes in expected/
+STD_ARGS = ('modis', '-s', NH_SHP_PATH, '-d', '2012-12-01,2012-12-03', '-v', '4')
 
 
 @pytest.fixture

--- a/gips/test/sys/t_repo_src_alteration.py
+++ b/gips/test/sys/t_repo_src_alteration.py
@@ -33,3 +33,13 @@ def t_modis_inv_fetch(careful_repo_env, expected):
             '-d', '2012-12-01,2012-12-01', '-v', '4', '--fetch')
     actual = careful_repo_env.run('gips_inventory', *args)
     assert expected == actual
+
+
+@src_altering
+def t_landsat_inv_fetch(careful_repo_env, expected):
+    """Test gips_inventory --fetch; actually contacts data provider."""
+    args = ('landsat', '-s', NH_SHP_PATH, '-d', '2015-352', '-v', '4', '--fetch')
+    actual = careful_repo_env.run('gips_inventory', *args)
+    # can't compare checksums because landsat's checksums are different every time.
+    assert (expected.created.keys() == actual.created.keys() and
+            expected.updated == actual.updated)

--- a/gips/test/unit/t_landsat.py
+++ b/gips/test/unit/t_landsat.py
@@ -1,0 +1,19 @@
+import pytest
+
+from ...data.landsat import landsat
+
+def actual(la):
+    # TODO: la.visbands, la.lwbands, and possibly la.meta
+    return (la.filename, la.asset, la.version, la.sensor,
+            la.date.year, la.date.timetuple().tm_yday)
+
+dn_fn = '/data-root/landsat/tiles/012030/2015352/LC80120302015352LGN00.tar.gz'
+sr_fn = '/data-root/landsat/tiles/026035/2015162/LC80260352015162-SC20160317174932.tar.gz'
+
+@pytest.mark.parametrize("fn, expected", [
+    (dn_fn, (dn_fn, 'DN', 0, 'LC8',   2015, 352)),
+    (sr_fn, (sr_fn, 'SR', 1, 'LC8SR', 2015, 162)),
+])
+def t_landsatAsset_constructor(fn, expected):
+    la = landsat.landsatAsset(fn)
+    assert expected == actual(la)


### PR DESCRIPTION
* Improvement to system test harness:  optionally ignore stderr emitted by programs under test
* Fix #61, which is related to hyphens in the name of directories in the GIPS data repo.
* For #61, first-ever unit tests for GIPS!  :tada: 
* System tests for landsat, which are similar to modis, including expectations file in `expected/landsat.py` and tests in `t_landsat.py`.  Inventory-fetch is tested in the same files as modis (they have more in common than not).  This maybe fixes #46 because there's comprehensive coverage (based on `landsat.sh`) but no atmo correction and not super-good performance.

Speaking of performance, I have a branch with a nascent caching system, but it's not quite ready and I don't like my branches to live too long.