### PR TITLE
63 modis auth

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
 pytest
+pytest-mock
 scripttest
 envoy

--- a/gips/data/modis/modis.py
+++ b/gips/data/modis/modis.py
@@ -211,7 +211,8 @@ class modisAsset(Asset):
                     # cookies / cache auth
 
                     kw = {'timeout': 10}
-                    if asset not in cls._skip_auth: kw['auth'] = (username, password)
+                    if asset not in cls._skip_auth:
+                        kw['auth'] = (username, password)
                     response = requests.get(url, **kw)
 
                     if response.status_code != requests.codes.ok:
@@ -220,7 +221,7 @@ class modisAsset(Asset):
                         return # might as well stop b/c the rest will probably fail too
 
                     with open(outpath, 'wb') as fd:
-                        for chunk in resp.iter_content():
+                        for chunk in response.iter_content():
                             fd.write(chunk)
 
                 except Exception:

--- a/gips/data/modis/modis.py
+++ b/gips/data/modis/modis.py
@@ -184,6 +184,9 @@ class modisAsset(Asset):
 
         success = False
         for item in listing:
+            # screen-scrape the content of the page and extract the full name of the needed file
+            # (this step is needed because part of the filename, the creation timestamp, is
+            # effectively random).
             if cpattern.search(item):
                 if 'xml' in item:
                     continue
@@ -199,10 +202,10 @@ class modisAsset(Asset):
                     output.close()
 
                 except urllib2.HTTPError as e:
-                    # keep going even if this fails because . . . TODO actually I don't know of a reason.
                     if e.code == 401:
                         print('Download of', name, 'failed:', e.reason, file=sys.stderr)
                         print('Full URL:', url, file=sys.stderr)
+                    return # might as well stop b/c the rest will probably fail too
                 except Exception:
                     # TODO - implement pre-check to only attempt on valid dates
                     # then uncomment this

--- a/gips/data/modis/modis.py
+++ b/gips/data/modis/modis.py
@@ -21,7 +21,10 @@
 #   along with this program. If not, see <http://www.gnu.org/licenses/>
 ################################################################################
 
+from __future__ import print_function
+
 import os
+import sys
 import re
 import datetime
 import urllib
@@ -166,7 +169,7 @@ class modisAsset(Asset):
         year, month, day = date.timetuple()[:3]
 
         if asset == "MCD12Q1" and (month != 1 or day != 1):
-            print "Land cover data are only available for Jan. 1"
+            print("Land cover data are only available for Jan. 1")
             return
 
         mainurl = "%s/%s.%02d.%02d" % (cls._assets[asset]['url'], str(year), month, day)
@@ -195,6 +198,11 @@ class modisAsset(Asset):
                     output.write(connection.read())
                     output.close()
 
+                except urllib2.HTTPError as e:
+                    # keep going even if this fails because . . . TODO actually I don't know of a reason.
+                    if e.code == 401:
+                        print('Download of', name, 'failed:', e.reason, file=sys.stderr)
+                        print('Full URL:', url, file=sys.stderr)
                 except Exception:
                     # TODO - implement pre-check to only attempt on valid dates
                     # then uncomment this
@@ -393,7 +401,7 @@ class modisData(Data):
                 evi[wg] = (2.5*(nirimg[wg] - redimg[wg])) / (nirimg[wg] + 6.0*redimg[wg] - 7.5*bluimg[wg] + 1.0)
 
                 # create output gippy image
-                print "writing", fname
+                print("writing", fname)
                 imgout = gippy.GeoImage(fname, refl, gippy.GDT_Int16, 6)
 
                 imgout.SetNoData(missing)
@@ -547,7 +555,7 @@ class modisData(Data):
                 fracout[mask] = 0
 
                 if totsnowcover == 0 or totsnowfrac == 0:
-                    print "no snow or ice: skipping", str(self.date), str(self.id), str(missingassets)
+                    print("no snow or ice: skipping", str(self.date), str(self.id), str(missingassets))
 
                 meta['FRACMISSINGCOVERCLEAR'] = fracmissingcoverclear
                 meta['FRACMISSINGCOVERSNOW'] = fracmissingcoversnow
@@ -671,7 +679,7 @@ class modisData(Data):
                 numvalidcover = np.sum(coverout != 127)
 
                 if totsnowcover == 0 or totsnowfrac == 0:
-                    print "no snow or ice: skipping", str(self.date), str(self.id), str(missingassets)
+                    print("no snow or ice: skipping", str(self.date), str(self.id), str(missingassets))
 
                 meta['FRACMISSINGCOVERCLEAR'] = fracmissingcoverclear
                 meta['FRACMISSINGCOVERSNOW'] = fracmissingcoversnow

--- a/gips/data/modis/modis.py
+++ b/gips/data/modis/modis.py
@@ -210,19 +210,25 @@ class modisAsset(Asset):
                     # chunk size & stream=True in req
                     # cookies / cache auth
 
-                    kw = {'timeout': 10}
-                    if asset not in cls._skip_auth:
-                        kw['auth'] = (username, password)
-                    response = requests.get(url, **kw)
+                    if mainurl[0:3] == 'ftp':
+                        connection = urllib2.urlopen(url)
+                        with open(outpath, 'wb') as fd:
+                            fd.write(connection.read())
 
-                    if response.status_code != requests.codes.ok:
-                        print('Download of', name, 'failed:', response.status_code, response.reason,
-                              '\nFull URL:', url, file=sys.stderr)
-                        return # might as well stop b/c the rest will probably fail too
+                    else: # http
+                        kw = {'timeout': 10}
+                        if asset not in cls._skip_auth:
+                            kw['auth'] = (username, password)
+                        response = requests.get(url, **kw)
 
-                    with open(outpath, 'wb') as fd:
-                        for chunk in response.iter_content():
-                            fd.write(chunk)
+                        if response.status_code != requests.codes.ok:
+                            print('Download of', name, 'failed:', response.status_code, response.reason,
+                                  '\nFull URL:', url, file=sys.stderr)
+                            return # might as well stop b/c the rest will probably fail too
+
+                        with open(outpath, 'wb') as fd:
+                            for chunk in response.iter_content():
+                                fd.write(chunk)
 
                 except Exception:
                     # TODO - implement pre-check to only attempt on valid dates

--- a/gips/test/unit/t_modis.py
+++ b/gips/test/unit/t_modis.py
@@ -1,0 +1,78 @@
+import datetime
+
+import pytest
+
+from ...data.modis import modis
+
+dt = datetime.datetime
+
+# everything for NH's tile for Dec 1 2012:
+params = (
+    (
+        ('MOD11A2', 'h12v04', dt(2012, 12, 1, 0, 0)),               # call
+        'http://e4ftl01.cr.usgs.gov/MOLT/MOD11A2.005/2012.12.01',   # passed to urlopen
+    ),
+    (
+        ('MYD11A1', 'h12v04', dt(2012, 12, 1, 0, 0)),
+        'http://e4ftl01.cr.usgs.gov/MOLA/MYD11A1.005/2012.12.01',
+    ),
+
+    (
+        ('MOD11A1', 'h12v04', dt(2012, 12, 1, 0, 0)),
+        'http://e4ftl01.cr.usgs.gov/MOLT/MOD11A1.005/2012.12.01',
+    ),
+
+        # probably test separately; it preumaturely returns
+        # ('MCD12Q1', 'h12v04', dt(2012, 12, 1, 0, 0)),
+
+    (
+        ('MCD43A2', 'h12v04', dt(2012, 12, 1, 0, 0)),
+        'http://e4ftl01.cr.usgs.gov/MOTA/MCD43A2.005/2012.12.01',
+    ),
+
+    (
+        ('MOD09Q1', 'h12v04', dt(2012, 12, 1, 0, 0)),
+        'http://e4ftl01.cr.usgs.gov/MOLT/MOD09Q1.005//2012.12.01',
+    ),
+
+    (
+        ('MCD43A4', 'h12v04', dt(2012, 12, 1, 0, 0)),
+        'http://e4ftl01.cr.usgs.gov/MOTA/MCD43A4.005/2012.12.01',
+    ),
+)
+
+
+@pytest.fixture
+def fetch_mocks(mocker):
+    urlopen = mocker.patch.object(modis.urllib, 'urlopen')
+
+    # called in a loop for items in the listing that match criteria
+    urlopen2 = mocker.patch.object(modis.urllib2, 'urlopen')
+    conn = urlopen2.return_value
+    # conn.read.return_value = "omnia dicta fortiora si dicta Latina."
+    open = mocker.patch.object(modis, 'open')
+    file = open.return_value
+    return (urlopen, urlopen2, conn, open, file)
+
+
+class T_modisAsset_fetch(object):
+
+    @pytest.mark.parametrize("call, expected", params)
+    def t_no_matching_listings(self, fetch_mocks, call, expected):
+	"""Unit test for modisAsset.fetch; uses mocking to prevent I/O."""
+	(urlopen, urlopen2, conn, open, file) = fetch_mocks
+
+	# give the listing from which names of asset files are extracted
+	urlopen.return_value.readlines.return_value = ("not", "your", "files")
+
+	modis.modisAsset.fetch(*call)
+
+        # It should skip the I/O code except for fetching the directory listing
+        uncalled_fns = (conn.read, urlopen2, open, file.write, file.close)
+        readlines = urlopen.return_value.readlines
+        assert not any([f.called for f in uncalled_fns]) and all([
+            readlines.call_count == 1,
+            readlines.call_args  == (),
+            urlopen.call_count   == 1,
+            urlopen.call_args    == ((expected,), {}) # (args, kwargs)
+        ])

--- a/gips/test/unit/t_modis.py
+++ b/gips/test/unit/t_modis.py
@@ -6,44 +6,39 @@ from ...data.modis import modis
 
 dt = datetime.datetime
 
-# everything for NH's tile for Dec 1 2012:
-params = (
-    (
-        ('MOD11A2', 'h12v04', dt(2012, 12, 1, 0, 0)),               # call
-        'http://e4ftl01.cr.usgs.gov/MOLT/MOD11A2.005/2012.12.01',   # passed to urlopen
-    ),
-    (
-        ('MYD11A1', 'h12v04', dt(2012, 12, 1, 0, 0)),
-        'http://e4ftl01.cr.usgs.gov/MOLA/MYD11A1.005/2012.12.01',
-    ),
+# probably test separately; it preumaturely returns: ('MCD12Q1', 'h12v04', dt(2012, 12, 1, 0, 0)),
 
-    (
-        ('MOD11A1', 'h12v04', dt(2012, 12, 1, 0, 0)),
-        'http://e4ftl01.cr.usgs.gov/MOLT/MOD11A1.005/2012.12.01',
-    ),
+# everything for NH's tile for Dec 1 2012 that fails:
+http_404_params = (
+    (('MOD11A2', 'h12v04', dt(2012, 12, 1, 0, 0)),                  # call
+        'http://e4ftl01.cr.usgs.gov/MOLT/MOD11A2.005/2012.12.01'),  # passed to urlopen
 
-        # probably test separately; it preumaturely returns
-        # ('MCD12Q1', 'h12v04', dt(2012, 12, 1, 0, 0)),
+    (('MCD43A2', 'h12v04', dt(2012, 12, 1, 0, 0)),
+        'http://e4ftl01.cr.usgs.gov/MOTA/MCD43A2.005/2012.12.01'),
 
-    (
-        ('MCD43A2', 'h12v04', dt(2012, 12, 1, 0, 0)),
-        'http://e4ftl01.cr.usgs.gov/MOTA/MCD43A2.005/2012.12.01',
-    ),
+    (('MOD09Q1', 'h12v04', dt(2012, 12, 1, 0, 0)),
+        'http://e4ftl01.cr.usgs.gov/MOLT/MOD09Q1.005//2012.12.01'),
 
-    (
-        ('MOD09Q1', 'h12v04', dt(2012, 12, 1, 0, 0)),
-        'http://e4ftl01.cr.usgs.gov/MOLT/MOD09Q1.005//2012.12.01',
-    ),
+    (('MCD43A4', 'h12v04', dt(2012, 12, 1, 0, 0)),
+        'http://e4ftl01.cr.usgs.gov/MOTA/MCD43A4.005/2012.12.01'),
+)
 
-    (
-        ('MCD43A4', 'h12v04', dt(2012, 12, 1, 0, 0)),
-        'http://e4ftl01.cr.usgs.gov/MOTA/MCD43A4.005/2012.12.01',
-    ),
+
+model_404 = (
+    '<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">\n',
+    '<html><head>\n',
+    '<title>404 Not Found</title>\n',
+    '</head><body>\n',
+    '<h1>Not Found</h1>\n',
+    # shouldn't matter what it says here vvv
+    '<p>The requested URL /MOLT/MOD11A2.005/2012.12.01 was not found on this server.</p>\n',
+    '</body></html>\n',
 )
 
 
 @pytest.fixture
 def fetch_mocks(mocker):
+    """Mock out all I/O used in modisAsset.fetch; used for unit tests below."""
     urlopen = mocker.patch.object(modis.urllib, 'urlopen')
 
     # called in a loop for items in the listing that match criteria
@@ -55,24 +50,132 @@ def fetch_mocks(mocker):
     return (urlopen, urlopen2, conn, open, file)
 
 
-class T_modisAsset_fetch(object):
+@pytest.mark.parametrize("call, expected", http_404_params)
+def t_no_matching_listings(fetch_mocks, call, expected):
+    """Unit test for modisAsset.fetch for assets that 404."""
+    (urlopen, urlopen2, conn, open, file) = fetch_mocks
 
-    @pytest.mark.parametrize("call, expected", params)
-    def t_no_matching_listings(self, fetch_mocks, call, expected):
-	"""Unit test for modisAsset.fetch; uses mocking to prevent I/O."""
-	(urlopen, urlopen2, conn, open, file) = fetch_mocks
+    # give the listing from which names of asset files are extracted
+    urlopen.return_value.readlines.return_value = model_404
 
-	# give the listing from which names of asset files are extracted
-	urlopen.return_value.readlines.return_value = ("not", "your", "files")
+    modis.modisAsset.fetch(*call)
 
-	modis.modisAsset.fetch(*call)
+    # It should skip the I/O code except for fetching the directory listing
+    uncalled_fns = (conn.read, urlopen2, open, file.write, file.close)
+    readlines = urlopen.return_value.readlines
+    assert not any([f.called for f in uncalled_fns]) and all([
+        readlines.call_count == 1,
+        readlines.call_args  == (),
+        urlopen.call_count   == 1,
+        urlopen.call_args    == ((expected,), {}) # (args, kwargs)
+    ])
 
-        # It should skip the I/O code except for fetching the directory listing
-        uncalled_fns = (conn.read, urlopen2, open, file.write, file.close)
-        readlines = urlopen.return_value.readlines
-        assert not any([f.called for f in uncalled_fns]) and all([
-            readlines.call_count == 1,
-            readlines.call_args  == (),
-            urlopen.call_count   == 1,
-            urlopen.call_args    == ((expected,), {}) # (args, kwargs)
-        ])
+
+# VERY truncated snippet of an actual listing file
+MYD11A1_listing = [
+    '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">\n',
+    '<html>\n',
+    ' <head>\n',
+    '  <title>Index of /MOLA/MYD11A1.005/2012.12.01</title>\n',
+    ' </head>\n',
+    ' <body>\n',
+    '<pre><img src="/icons/blank.gif" alt="Icon "> <a href="?C=N;O=D">Name</a>',
+    '<img src="/icons/unknown.gif" alt="[   ]">'
+        '<a href="MYD11A1.A2012336.h12v03.005.2012341040539.hdf">'
+        'MYD11A1.A2012336.h12v03.005.2012341040539.hdf</a>          2012-12-05 22:15  2.4M  \n',
+    '<img src="/icons/unknown.gif" alt="[   ]">'
+        '<a href="MYD11A1.A2012336.h12v03.005.2012341040539.hdf.xml">'
+        'MYD11A1.A2012336.h12v03.005.2012341040539.hdf.xml</a>      2012-12-06 02:22   11K  \n',
+    '<img src="/icons/unknown.gif" alt="[   ]">'
+        '<a href="MYD11A1.A2012336.h12v04.005.2012341040543.hdf">'
+        'MYD11A1.A2012336.h12v04.005.2012341040543.hdf</a>          2012-12-05 22:15  1.2M  \n',
+    '<img src="/icons/unknown.gif" alt="[   ]">'
+        '<a href="MYD11A1.A2012336.h12v04.005.2012341040543.hdf.xml">'
+        'MYD11A1.A2012336.h12v04.005.2012341040543.hdf.xml</a>      2012-12-06 02:22  9.5K  \n',
+    '<img src="/icons/unknown.gif" alt="[   ]">'
+        '<a href="MYD11A1.A2012336.h12v05.005.2012341040552.hdf">'
+        'MYD11A1.A2012336.h12v05.005.2012341040552.hdf</a>          2012-12-05 22:15  382K  \n',
+    '<hr></pre>\n',
+    '</body></html>\n'
+]
+
+
+MOD11A1_listing = [
+    '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">\n',
+    '<html>\n',
+    ' <head>\n',
+    '  <title>Index of /MOLT/MOD11A1.005/2012.12.01</title>\n',
+    ' </head>\n',
+    ' <body>\n',
+    '<pre><img src="/icons/blank.gif" alt="Icon "> <a href="?C=N;O=D">Name</a>',
+    '<img src="/icons/unknown.gif" alt="[   ]">'
+        '<a href="MOD11A1.A2012336.h12v02.005.2012339180538.hdf.xml">'
+        'MOD11A1.A2012336.h12v02.005.2012339180538.hdf.xml</a>      2012-12-05 02:13   14K  \n',
+    '<img src="/icons/unknown.gif" alt="[   ]">'
+        '<a href="MOD11A1.A2012336.h12v03.005.2012339180912.hdf">'
+        'MOD11A1.A2012336.h12v03.005.2012339180912.hdf</a>          2012-12-04 12:29  3.6M  \n',
+    '<img src="/icons/unknown.gif" alt="[   ]">'
+        '<a href="MOD11A1.A2012336.h12v03.005.2012339180912.hdf.xml">'
+        'MOD11A1.A2012336.h12v03.005.2012339180912.hdf.xml</a>      2012-12-05 02:13   10K  \n',
+    '<img src="/icons/unknown.gif" alt="[   ]">'
+        '<a href="MOD11A1.A2012336.h12v04.005.2012339180517.hdf">'
+        'MOD11A1.A2012336.h12v04.005.2012339180517.hdf</a>          2012-12-04 12:29  1.8M  \n',
+    '<img src="/icons/unknown.gif" alt="[   ]">'
+        '<a href="MOD11A1.A2012336.h12v04.005.2012339180517.hdf.xml">'
+        'MOD11A1.A2012336.h12v04.005.2012339180517.hdf.xml</a>      2012-12-05 02:13  9.0K  \n',
+    '<img src="/icons/unknown.gif" alt="[   ]">'
+        '<a href="MOD11A1.A2012336.h12v05.005.2012339042544.hdf">'
+        'MOD11A1.A2012336.h12v05.005.2012339042544.hdf</a>          2012-12-03 23:44  385K  \n',
+    '<img src="/icons/unknown.gif" alt="[   ]">'
+        '<a href="MOD11A1.A2012336.h12v05.005.2012339042544.hdf.xml">'
+        'MOD11A1.A2012336.h12v05.005.2012339042544.hdf.xml</a>      2012-12-04 02:12  9.4K  \n',
+    '<hr></pre>\n',
+    '</body></html>\n'
+]
+
+
+# everything for NH's tile for Dec 1 2012 that succeeds, including both inputs and outputs
+http_200_params = (
+    (('MYD11A1', 'h12v04', dt(2012, 12, 1, 0, 0)),
+        'http://e4ftl01.cr.usgs.gov/MOLA/MYD11A1.005/2012.12.01',
+        MYD11A1_listing, # big damn html listing
+        'MYD11A1.A2012336.h12v04.005.2012341040543.hdf'),
+
+    (('MOD11A1', 'h12v04', dt(2012, 12, 1, 0, 0)),
+        'http://e4ftl01.cr.usgs.gov/MOLT/MOD11A1.005/2012.12.01',
+        MOD11A1_listing, # big damn html listing
+        'MOD11A1.A2012336.h12v04.005.2012339180517.hdf'),
+)
+
+
+@pytest.mark.parametrize("call, listing_url, listing, asset_fn", http_200_params)
+def t_match_all_the_things(fetch_mocks, call, listing_url, listing, asset_fn):
+    """test modisAsset.fetch:  Query server, extract URL, then download it."""
+    (urlopen, urlopen2, conn, open, file) = fetch_mocks
+
+    # give the listing from which names of asset files are extracted
+    urlopen.return_value.readlines.return_value = listing
+    conn.read.return_value == ("If you think you understand, you don't.  "
+                               "If you think you don't understand, you still don't.")
+
+    modis.modisAsset.fetch(*call)
+
+    # These assertions are too involved, possibly, because fetch() does too much
+    readlines = urlopen.return_value.readlines
+    (open_fn, open_mode) = open.call_args[0] # [1] is kwargs remember
+    assert all([
+        readlines.call_count == 1,
+        readlines.call_args  == (),
+        urlopen.call_count   == 1,
+        urlopen.call_args    == ((listing_url,), {}), # (args, kwargs)
+        urlopen2.call_count  == 1,
+        urlopen2.call_args   == ((listing_url + '/' + asset_fn,), {}),
+        open.call_count      == 1,
+        open_fn.endswith(asset_fn),
+        open_mode            == 'wb',
+        conn.read.call_count == 1,
+        conn.read.call_args  == (),
+        # not checking file.close because its failure is believed to be low-impact.
+        file.write.call_count == 1,
+        file.write.call_args  == ((conn.read.return_value,), {}),
+    ])

--- a/gips/test/unit/t_modis_fetch.py
+++ b/gips/test/unit/t_modis_fetch.py
@@ -152,7 +152,7 @@ http_200_params = (
 
 
 @pytest.mark.parametrize("call, listing_url, listing, asset_fn", http_200_params)
-def t_match_all_the_things(fetch_mocks, call, listing_url, listing, asset_fn):
+def t_matching_listings(fetch_mocks, call, listing_url, listing, asset_fn):
     """test modisAsset.fetch:  Query server, extract URL, then download it."""
     (urlopen, urlopen2, conn, open, file) = fetch_mocks
 

--- a/gips/test/unit/t_modis_fetch.py
+++ b/gips/test/unit/t_modis_fetch.py
@@ -56,7 +56,7 @@ def fetch_mocks(mocker):
 
 
 @pytest.mark.parametrize("call, expected", http_404_params)
-def t_no_matching_listings(fetch_mocks, call, expected):
+def t_no_http_matching_listings(fetch_mocks, call, expected):
     """Unit test for modisAsset.fetch for assets that 404."""
     (urlopen, get, response, open, file) = fetch_mocks
 
@@ -154,8 +154,8 @@ http_200_params = (
 
 
 @pytest.mark.parametrize("call, listing_url, listing, asset_fn", http_200_params)
-def t_matching_listings(mocker, fetch_mocks, call, listing_url, listing, asset_fn):
-    """test modisAsset.fetch:  Query server, extract URL, then download it."""
+def t_http_matching_listings(mocker, fetch_mocks, call, listing_url, listing, asset_fn):
+    """Query http server, extract asset URL, then download it."""
     (urlopen, get, response, open, file) = fetch_mocks
 
     # rely on the real one because mocking was too painful
@@ -183,6 +183,102 @@ def t_matching_listings(mocker, fetch_mocks, call, listing_url, listing, asset_f
     # file write assertions:  open(...) as fd && fd.write(...)
     assert open.call_args[0][0].endswith(asset_fn) # did we open the right filename?
     file.write.assert_has_calls([mock.call(c) for c in content])
+
+
+MOD10A1_listing = ['total 184064\r\n',  # drastically foreshortened ftp listing
+    'lrwxrwxrwx  1 7372 90      97 Nov 23  2015 '
+        'BROWSE.MOD10A1.A2012336.h12v02.005.2012339213026.1.jpg -> '
+        '../../../../DP0/BRWS/Browse.001/2012.12.04/'
+        'BROWSE.MOD10A1.A2012336.h12v02.005.2012339213026.1.jpg\r\n',
+    'lrwxrwxrwx  1 7372 90      97 Nov 23  2015 '
+        'BROWSE.MOD10A1.A2012336.h12v03.005.2012339212814.1.jpg -> '
+        '../../../../DP0/BRWS/Browse.001/2012.12.04/BROWSE.MOD10A1.A2012336.h12v03.005.2012339212814.1.jpg\r\n',
+    'lrwxrwxrwx  1 7372 90      97 Nov 23  2015 '
+        'BROWSE.MOD10A1.A2012336.h12v04.005.2012339213007.1.jpg -> '
+        '../../../../DP0/BRWS/Browse.001/2012.12.04/BROWSE.MOD10A1.A2012336.h12v04.005.2012339213007.1.jpg\r\n',
+    'lrwxrwxrwx  1 7372 90      97 Nov 23  2015 '
+        'BROWSE.MOD10A1.A2012336.h12v05.005.2012339213007.1.jpg -> '
+        '../../../../DP0/BRWS/Browse.001/2012.12.04/BROWSE.MOD10A1.A2012336.h12v05.005.2012339213007.1.jpg\r\n',
+    'lrwxrwxrwx  1 7372 90      97 Nov 23  2015 '
+        'BROWSE.MOD10A1.A2012336.h12v07.005.2012339212842.1.jpg -> '
+        '../../../../DP0/BRWS/Browse.001/2012.12.04/BROWSE.MOD10A1.A2012336.h12v07.005.2012339212842.1.jpg\r\n',
+    '-rw-r--r--  1 7372 90    8711 Jan 15  2013 '
+        'MOD10A1.A2012336.h12v02.005.2012339213026.hdf.xml\r\n',
+    '-rw-r--r--  1 7372 90 1137281 Dec  4  2012 MOD10A1.A2012336.h12v03.005.2012339212814.hdf\r\n',
+    '-rw-r--r--  1 7372 90    8710 Jan 15  2013 '
+        'MOD10A1.A2012336.h12v03.005.2012339212814.hdf.xml\r\n',
+    '-rw-r--r--  1 7372 90  844320 Dec  4  2012 MOD10A1.A2012336.h12v04.005.2012339213007.hdf\r\n',
+    '-rw-r--r--  1 7372 90    7935 Jan 15  2013 '
+        'MOD10A1.A2012336.h12v04.005.2012339213007.hdf.xml\r\n',
+    '-rw-r--r--  1 7372 90  131621 Dec  4  2012 MOD10A1.A2012336.h12v05.005.2012339213007.hdf\r\n',
+]
+
+
+MYD10A1_listing = ['total 184704\r\n', # drastically foreshortened ftp listing
+    'lrwxrwxrwx  1 7372 90      97 Dec  5  2015 '
+        'BROWSE.MYD10A1.A2012336.h12v02.005.2012340031948.1.jpg -> '
+        '../../../../DP0/BRWS/Browse.001/2012.12.05/BROWSE.MYD10A1.A2012336.h12v02.005.2012340031948.1.jpg\r\n',
+    'lrwxrwxrwx  1 7372 90      97 Dec  5  2015 '
+        'BROWSE.MYD10A1.A2012336.h12v03.005.2012340032022.1.jpg -> '
+        '../../../../DP0/BRWS/Browse.001/2012.12.05/BROWSE.MYD10A1.A2012336.h12v03.005.2012340032022.1.jpg\r\n',
+    'lrwxrwxrwx  1 7372 90      97 Dec  5  2015 '
+        'BROWSE.MYD10A1.A2012336.h12v04.005.2012340031954.1.jpg -> '
+        '../../../../DP0/BRWS/Browse.001/2012.12.05/BROWSE.MYD10A1.A2012336.h12v04.005.2012340031954.1.jpg\r\n',
+    'lrwxrwxrwx  1 7372 90      97 Dec  5  2015 '
+        'BROWSE.MYD10A1.A2012336.h12v05.005.2012340032147.1.jpg -> '
+        '../../../../DP0/BRWS/Browse.001/2012.12.05/BROWSE.MYD10A1.A2012336.h12v05.005.2012340032147.1.jpg\r\n',
+    'lrwxrwxrwx  1 7372 90      97 Dec  5  2015 '
+        'BROWSE.MYD10A1.A2012336.h12v02.005.2012340031948.1.jpg -> '
+        '../../../../DP0/BRWS/Browse.001/2012.12.05/BROWSE.MYD10A1.A2012336.h12v02.005.2012340031948.1.jpg\r\n',
+    'lrwxrwxrwx  1 7372 90      97 Dec  5  2015 '
+        'BROWSE.MYD10A1.A2012336.h12v03.005.2012340032022.1.jpg -> '
+        '../../../../DP0/BRWS/Browse.001/2012.12.05/BROWSE.MYD10A1.A2012336.h12v03.005.2012340032022.1.jpg\r\n',
+    'lrwxrwxrwx  1 7372 90      97 Dec  5  2015 '
+        'BROWSE.MYD10A1.A2012336.h12v04.005.2012340031954.1.jpg -> '
+        '../../../../DP0/BRWS/Browse.001/2012.12.05/BROWSE.MYD10A1.A2012336.h12v04.005.2012340031954.1.jpg\r\n',
+    '-rw-r--r--  1 7372 90    8304 Jan 10  2013 MYD10A1.A2012336.h12v03.005.2012340032022.hdf.xml\r\n',
+    '-rw-r--r--  1 7372 90  262727 Dec  4  2012 MYD10A1.A2012336.h12v04.005.2012340031954.hdf\r\n',
+    '-rw-r--r--  1 7372 90    7916 Jan 10  2013 MYD10A1.A2012336.h12v04.005.2012340031954.hdf.xml\r\n',
+    '-rw-r--r--  1 7372 90  164381 Dec  4  2012 MYD10A1.A2012336.h12v05.005.2012340032147.hdf\r\n',
+    '-rw-r--r--  1 7372 90    7920 Jan 10  2013 MYD10A1.A2012336.h12v05.005.2012340032147.hdf.xml\r\n',
+]
+
+
+@pytest.mark.parametrize("call, listing_url, listing, asset_fn", (
+    (('MYD10A1', 'h12v04', dt(2012, 12, 1, 0, 0)),
+        'ftp://n5eil01u.ecs.nsidc.org/SAN/MOSA/MYD10A1.005/2012.12.01',
+        MYD10A1_listing, # FTP index page
+        'MYD10A1.A2012336.h12v04.005.2012340031954.hdf'),
+    (('MOD10A1', 'h12v04', dt(2012, 12, 1, 0, 0)),
+        'ftp://n5eil01u.ecs.nsidc.org/SAN/MOST/MOD10A1.005/2012.12.01',
+        MOD10A1_listing, # FTP index page
+        'MOD10A1.A2012336.h12v04.005.2012339213007.hdf'),
+    )
+)
+def t_ftp_matching_listings(mocker, fetch_mocks, call, listing_url, listing, asset_fn):
+    """Query ftp server, extract asset URL, then download it."""
+    (urlopen, get, _, open, file) = fetch_mocks
+
+    # give the listing from which names of asset files are extracted
+    urlopen.return_value.readlines.return_value = listing
+    # content returned by ftp download
+    content = ("If you think you understand, you don't.  \n"
+               "If you think you don't understand, you still don't.")
+    urlopen2 = mocker.patch.object(modis.urllib2, 'urlopen')
+    connection = urlopen2.return_value
+    connection.read.return_value = content
+
+    modis.modisAsset.fetch(*call)
+
+    # listing assertions:  urllib.urlopen(mainurl).readlines()
+    urlopen.assert_called_once_with(listing_url)
+    urlopen.return_value.readlines.assert_called_once_with()
+    # test the way the url was opened
+    get.assert_not_called() # should use urllib2 instead
+    urlopen2.assert_called_once_with(listing_url + '/' + asset_fn)
+    # file write assertions:  open(...) as fd && fd.write(...)
+    assert open.call_args[0][0].endswith(asset_fn) # did we open the right filename?
+    file.write.assert_called_once_with(content)
 
 
 def t_auth_settings(mocker, fetch_mocks):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 six==1.9.0
+requests


### PR DESCRIPTION
This is a fix for #63.

Replace urllib2 with requests for http fetches, but it doesn't support ftp so continue to use urllib2 for that.  A new constant in `modisAsset` tells which asset data need auth.  Auth creds are taken from settings; unfortunately there's no way around storing them in plaintext for the time being.

`modisAsset.fetch` is now covered by unit tests, which are complex becaues `fetch` does lots of I/O.

Note that the key system test which exercises `fetch()` passes right now:

```py.test --src-altering gips/test/sys/t_repo_src_alteration.py::t_modis_inv_fetch```

Many of the rest of the system tests fail due to an unrelated problem at the moment, but these should not be dependent on the fetch method.