### PR TITLE
For convenient testing, overridable version string

### DIFF
--- a/gips/__init__.py
+++ b/gips/__init__.py
@@ -20,4 +20,19 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program. If not, see <http://www.gnu.org/licenses/>
 ################################################################################
-from .version import __version__
+
+from .utils import settings
+
+from . import version
+
+def detect_version():
+    """Emit GIPS' software version.  May be overridden for testing purposes.
+
+    To override version.py, put a desired version string into the setting
+    OVERRIDE_VERSION."""
+    ov = getattr(settings(), 'OVERRIDE_VERSION', None)
+    if ov is not None:
+        return ov
+    return version.__version__
+
+__version__ = detect_version()

--- a/gips/__init__.py
+++ b/gips/__init__.py
@@ -21,18 +21,15 @@
 #   along with this program. If not, see <http://www.gnu.org/licenses/>
 ################################################################################
 
-from .utils import settings
+import os
 
 from . import version
 
 def detect_version():
     """Emit GIPS' software version.  May be overridden for testing purposes.
 
-    To override version.py, put a desired version string into the setting
-    OVERRIDE_VERSION."""
-    ov = getattr(settings(), 'OVERRIDE_VERSION', None)
-    if ov is not None:
-        return ov
-    return version.__version__
+    To override version.py, put a desired version string in the environment
+    variable GIPS_OVERRIDE_VERSION."""
+    return os.environ.get('GIPS_OVERRIDE_VERSION', version.__version__)
 
 __version__ = detect_version()

--- a/gips/test/unit/t_core.py
+++ b/gips/test/unit/t_core.py
@@ -1,0 +1,24 @@
+"""Unit tests for core functions, such as those found in data.core."""
+
+import sys
+
+import pytest
+import mock
+
+from ...utils import settings
+
+import gips
+
+def t_version_override(mocker):
+    """Test Data.meta_dict() for correct override of __version__."""
+    settings_fn = mocker.patch.object(gips, 'settings')
+    settings_obj = mock.Mock(spec=['EMAIL']) # nothing but EMAIL is available now
+    settings_fn.return_value = settings_obj
+
+    gips.version.__version__ = 'orig-version' # no mocking, just overwrite
+    version_a = gips.detect_version()
+
+    settings_obj.OVERRIDE_VERSION = 'overridden-version'
+    version_b = gips.detect_version()
+
+    assert (version_a, version_b) == ('orig-version', 'overridden-version')


### PR DESCRIPTION
Fix for the testing problem induced by altering the version string:  GIPS puts its version number in files it generates as useful metadata for the files' provenance.  Now users can specify an appropriate override for the GIPS version to ensure tests pass.  Currently the right value for testing is:

`GIPS_OVERRIDE_VERSION='0.8.2'`

In the future the generated file checksums should be changed to match a permanent version string such as '0.0.0-dev' or something similar, which would then be a requisite for performing system tests, so that someday when GIPS' version string increments it'll be less confusing.