### PR TITLE
Fix for #44, add support for modis collection 6 (and retain support for 5)

### DIFF
--- a/gips/data/core.py
+++ b/gips/data/core.py
@@ -421,7 +421,7 @@ class Asset(object):
             newfilename = os.path.join(tpath, bname)
             if not os.path.exists(newfilename):
                 # check if another asset exists
-                existing = cls.discover(asset.tile, d, asset.asset)                
+                existing = cls.discover(asset.tile, d, asset.asset)
                 if(len(existing) > 0 and
                    (not update or not existing[0].updated(asset))):
                     VerboseOut('%s: other version(s) already exists:' % bname, 1)

--- a/gips/data/core.py
+++ b/gips/data/core.py
@@ -793,16 +793,16 @@ class Data(object):
         return set(assets)
 
     @classmethod
-    def fetch(cls, products, tiles, textent):
-        """ Download data for tiles and add to archive """
+    def fetch(cls, products, tiles, textent, update=False):
+        """ Download data for tiles and add to archive. update forces fetch """
         assets = cls.products2assets(products)
         fetched = []
         for a in assets:
             for t in tiles:
                 asset_dates = cls.Asset.dates(a, t, textent.datebounds, textent.daybounds)
                 for d in asset_dates:
-                    # if we don't have it already
-                    if not cls.Asset.discover(t, d, a):
+                    # if we don't have it already, or if update (force) flag
+                    if not cls.Asset.discover(t, d, a) or update == True:
                         try:
                             cls.Asset.fetch(a, t, d)
                             fetched.append((a, t, d))

--- a/gips/data/core.py
+++ b/gips/data/core.py
@@ -421,7 +421,7 @@ class Asset(object):
             newfilename = os.path.join(tpath, bname)
             if not os.path.exists(newfilename):
                 # check if another asset exists
-                existing = cls.discover(asset.tile, d, asset.asset)
+                existing = cls.discover(asset.tile, d, asset.asset)                
                 if(len(existing) > 0 and
                    (not update or not existing[0].updated(asset))):
                     VerboseOut('%s: other version(s) already exists:' % bname, 1)

--- a/gips/data/modis/modis.py
+++ b/gips/data/modis/modis.py
@@ -319,7 +319,7 @@ class modisData(Data):
                 else:
                     availassets.append(asset)
                     allsds.extend(sds)
-                    versions[asset] = int(re.findall('MCD43A4.*\.00(\d)\.\d{13}\.hdf', sds[0])[0])
+                    versions[asset] = int(re.findall('M.*\.00(\d)\.\d{13}\.hdf', sds[0])[0])
 
             if not availassets:
                 # some products aren't available for every day but this is trying every day

--- a/gips/data/modis/modis.py
+++ b/gips/data/modis/modis.py
@@ -271,7 +271,8 @@ class modisData(Data):
     _productgroups = {
         "Nadir BRDF-Adjusted 16-day": ['indices', 'quality'],
         "Terra/Aqua Daily": ['snow', 'temp', 'obstime', 'fsnow'],
-        "Terra 8-day": ['ndvi8', 'temp8tn', 'temp8td'],
+        # "Terra 8-day": ['ndvi8', 'temp8tn', 'temp8td'], # ndvi8 is deactivated for now
+        "Terra 8-day": ['temp8tn', 'temp8td'],
     }
     _products = {
         # MCD Products
@@ -305,10 +306,12 @@ class modisData(Data):
             'assets': ['MOD11A1', 'MYD11A1'],
         },
         # Misc
-        'ndvi8': {
-            'description': 'Normalized Difference Vegetation Index: 250m',
-            'assets': ['MOD09Q1'],
-        },
+        # ndvi8 fails and causes errors further down the processing run for a run like this:
+        # gips_process modis -s NHseacoast.shp -d 2012-12-02,2012-12-03 -v 4
+        #'ndvi8': {
+        #    'description': 'Normalized Difference Vegetation Index: 250m',
+        #    'assets': ['MOD09Q1'],
+        #},
         'temp8td': {
             'description': 'Surface temperature: 1km',
             'assets': ['MOD11A2'],
@@ -376,6 +379,7 @@ class modisData(Data):
 
 
             if val[0] == "refl":
+                # NOTE this code is unreachable (no refl entry in _products)
                 if versions[asset] != 6:
                     raise Exception('product version not supported')
                 sensor = 'MCD'
@@ -502,6 +506,7 @@ class modisData(Data):
                 meta['VERSION'] = VERSION
                 sensor = 'MOD'
                 fname = '%s_%s_%s' % (bname, sensor, key)
+
 
                 img = gippy.GeoImage(allsds)
 
@@ -942,6 +947,7 @@ class modisData(Data):
             ###################################################################
             # NDVI (8-day) - Terra only
             if val[0] == "ndvi8":
+                # NOTE this code is unreachable currently; see _products above.
                 VERSION = "1.0"
                 meta['VERSION'] = VERSION
                 sensor = 'MOD'

--- a/gips/inventory.py
+++ b/gips/inventory.py
@@ -34,8 +34,6 @@ from gips.utils import VerboseOut, Colors
 from gips.data.core import Data
 from gips.mapreduce import MapReduce
 
-from pdb import set_trace
-
 
 class Inventory(object):
     """ Base class for inventories """
@@ -253,8 +251,6 @@ class DataInventory(Inventory):
         self.products = dataclass.RequestedProducts(products)
 
         self.update = update
-
-        print "datainventory"
 
         if fetch:
             try:

--- a/gips/inventory.py
+++ b/gips/inventory.py
@@ -34,6 +34,8 @@ from gips.utils import VerboseOut, Colors
 from gips.data.core import Data
 from gips.mapreduce import MapReduce
 
+from pdb import set_trace
+
 
 class Inventory(object):
     """ Base class for inventories """
@@ -234,7 +236,7 @@ class ProjectInventory(Inventory):
 class DataInventory(Inventory):
     """ Manager class for data inventories (collection of Tiles class) """
 
-    def __init__(self, dataclass, spatial, temporal, products=None, fetch=False, **kwargs):
+    def __init__(self, dataclass, spatial, temporal, products=None, fetch=False, update=False, **kwargs):
         """ Create a new inventory
         :dataclass: The Data class to use (e.g., LandsatData, ModisData)
         :spatial: The spatial extent requested
@@ -250,9 +252,13 @@ class DataInventory(Inventory):
         self.temporal = temporal
         self.products = dataclass.RequestedProducts(products)
 
+        self.update = update
+
+        print "datainventory"
+
         if fetch:
             try:
-                dataclass.fetch(self.products.base, self.spatial.tiles, self.temporal)
+                dataclass.fetch(self.products.base, self.spatial.tiles, self.temporal, self.update)
             except Exception, e:
                 raise Exception('Error downloading %s: %s' % (dataclass.name, e))
             dataclass.Asset.archive(Repository.path('stage'))

--- a/gips/inventory.py
+++ b/gips/inventory.py
@@ -261,7 +261,7 @@ class DataInventory(Inventory):
                 dataclass.fetch(self.products.base, self.spatial.tiles, self.temporal, self.update)
             except Exception, e:
                 raise Exception('Error downloading %s: %s' % (dataclass.name, e))
-            dataclass.Asset.archive(Repository.path('stage'))
+            dataclass.Asset.archive(Repository.path('stage'), update=self.update)
 
         # find data
         self.data = {}

--- a/gips/parsers.py
+++ b/gips/parsers.py
@@ -81,6 +81,8 @@ class GIPSParser(argparse.ArgumentParser):
         group.add_argument('--%cov', dest='pcov', help='Threshold of %% tile coverage over site', default=0, type=int)
         group.add_argument('--%tile', dest='ptile', help='Threshold of %% tile used', default=0, type=int)
         group.add_argument('--fetch', help='Fetch any missing data (if supported)', default=False, action='store_true')
+        group.add_argument('--update', help='Force fetch and/ or update data (if supported)', default=False, action='store_true')
+
         group.add_argument('-v', '--verbose', help='Verbosity - 0: quiet, 1: normal, 2: debug', default=1, type=int)
         group.add_argument('-p', '--products', help='Requested Products', nargs='*')
         self.parent_parsers.append(parser)

--- a/gips/scripts/inventory.py
+++ b/gips/scripts/inventory.py
@@ -27,7 +27,6 @@ from gips.core import SpatialExtent, TemporalExtent
 from gips.utils import Colors, VerboseOut, open_vector, import_data_class
 from gips.inventory import DataInventory
 
-from pdb import set_trace
 
 def main():
     title = Colors.BOLD + 'GIPS Data Inventory (v%s)' % gipsversion + Colors.OFF
@@ -45,7 +44,6 @@ def main():
 
         extents = SpatialExtent.factory(cls, args.site, args.key, args.where, 
                                         args.tiles, args.pcov, args.ptile)
-
         for extent in extents:
             inv = DataInventory(cls, extent, TemporalExtent(args.dates, args.days), **vars(args))
             inv.pprint(md=args.md)            

--- a/gips/scripts/inventory.py
+++ b/gips/scripts/inventory.py
@@ -27,6 +27,7 @@ from gips.core import SpatialExtent, TemporalExtent
 from gips.utils import Colors, VerboseOut, open_vector, import_data_class
 from gips.inventory import DataInventory
 
+from pdb import set_trace
 
 def main():
     title = Colors.BOLD + 'GIPS Data Inventory (v%s)' % gipsversion + Colors.OFF
@@ -44,6 +45,7 @@ def main():
 
         extents = SpatialExtent.factory(cls, args.site, args.key, args.where, 
                                         args.tiles, args.pcov, args.ptile)
+
         for extent in extents:
             inv = DataInventory(cls, extent, TemporalExtent(args.dates, args.days), **vars(args))
             inv.pprint(md=args.md)            

--- a/gips/test/sys/expected/modis.py
+++ b/gips/test/sys/expected/modis.py
@@ -1,6 +1,6 @@
 """Known-good outcomes for tests, mostly stdout and created files."""
 
-t_inventory = { 'stdout': """\x1b[1mGIPS Data Inventory (v0.8.2)\x1b[0m
+t_inventory = { 'stdout': u"""\x1b[1mGIPS Data Inventory (v0.8.2)\x1b[0m
 Retrieving inventory for site NHseacoast-0
 
 \x1b[1mAsset Coverage for site NHseacoast-0\x1b[0m
@@ -11,49 +11,68 @@ Tile Coverage
 
 \x1b[1m\x1b[4m    DATE     MCD12Q1   MCD43A2   MCD43A4   MOD09Q1   MOD10A1   MOD10A2   MOD11A1   MOD11A2   MYD10A1   MYD10A2   MYD11A1   MYD11A2   Product  \x1b[0m
 \x1b[1m2012        
-\x1b[0m    336                                               100.0%               100.0%               100.0%               100.0%             \n    337                 100.0%     100.0%     100.0%     100.0%               100.0%     100.0%     100.0%               100.0%             \n    338                                               100.0%               100.0%               100.0%               100.0%             \n\n\n3 files on 3 dates\n\x1b[1m\nSENSORS\x1b[0m\n\x1b[35mMCD: Aqua/Terra Combined\x1b[0m\n\x1b[31mMOD: Terra\x1b[0m\n\x1b[32mMOD-MYD: Aqua/Terra together\x1b[0m\n\x1b[34mMYD: Aqua\x1b[0m
+\x1b[0m    336                 100.0%     100.0%               100.0%               100.0%               100.0%               100.0%             
+    337                 100.0%     100.0%               100.0%               100.0%     100.0%     100.0%               100.0%             
+    338                 100.0%     100.0%               100.0%               100.0%               100.0%               100.0%             
+
+
+3 files on 3 dates
+\x1b[1m
+SENSORS\x1b[0m
+\x1b[35mMCD: Aqua/Terra Combined\x1b[0m
+\x1b[31mMOD: Terra\x1b[0m
+\x1b[32mMOD-MYD: Aqua/Terra together\x1b[0m
+\x1b[34mMYD: Aqua\x1b[0m
 """
 }
+
 
 t_process = {
     'updated': {'modis/tiles/h12v04/2012336': None,
              'modis/tiles/h12v04/2012337': None,
              'modis/tiles/h12v04/2012338': None},
     'created': {
-        # TODO Are these broken or what?  Each None is a broken symlink:
+        # TODO Are these broken or what?  Each None is a broken symlink that seems to rely on weird
+        # gdal behavior (it uses the broken target of the symlink as a sort of data identifier?):
         # See https://github.com/Applied-GeoSolutions/gips/issues/54
+        'modis/tiles/h12v04/2012336/h12v04_2012336_MCD_quality.tif': None,
         'modis/tiles/h12v04/2012337/h12v04_2012337_MCD_quality.tif': None,
         'modis/tiles/h12v04/2012337/h12v04_2012337_MOD_temp8td.tif': None,
         'modis/tiles/h12v04/2012337/h12v04_2012337_MOD_temp8tn.tif': None,
+        'modis/tiles/h12v04/2012338/h12v04_2012338_MCD_quality.tif': None,
+        'modis/tiles/h12v04/2012336/MCD43A2.A2012336.h12v04.006.2016112010833.hdf.index': 1818315139,
+        'modis/tiles/h12v04/2012336/MCD43A4.A2012336.h12v04.006.2016112010833.hdf.index': 502383905,
         'modis/tiles/h12v04/2012336/MOD10A1.A2012336.h12v04.005.2012339213007.hdf.index': -1075525670,
         'modis/tiles/h12v04/2012336/MOD11A1.A2012336.h12v04.005.2012339180517.hdf.index': -1602319177,
         'modis/tiles/h12v04/2012336/MYD10A1.A2012336.h12v04.005.2012340031954.hdf.index': 1623945316,
         'modis/tiles/h12v04/2012336/MYD11A1.A2012336.h12v04.005.2012341040543.hdf.index': -1720582124,
         'modis/tiles/h12v04/2012336/h12v04_2012336_MCD_fsnow.tif': -843500181,
+        'modis/tiles/h12v04/2012336/h12v04_2012336_MCD_indices.tif': -1977616018,
         'modis/tiles/h12v04/2012336/h12v04_2012336_MCD_snow.tif': 388495321,
         'modis/tiles/h12v04/2012336/h12v04_2012336_MOD-MYD_obstime.tif': 1994827924,
         'modis/tiles/h12v04/2012336/h12v04_2012336_MOD-MYD_temp.tif': 2094570047,
         'modis/tiles/h12v04/2012336/h12v04_2012336_MOD_clouds.tif': 161070470,
-        'modis/tiles/h12v04/2012337/MCD43A2.A2012337.h12v04.005.2012356160504.hdf.index': 1869798455,
-        'modis/tiles/h12v04/2012337/MCD43A4.A2012337.h12v04.005.2012356160504.hdf.index': 1702701995,
-        'modis/tiles/h12v04/2012337/MOD09Q1.A2012337.h12v04.005.2012346141041.hdf.index': 1528708875,
+        'modis/tiles/h12v04/2012337/MCD43A2.A2012337.h12v04.006.2016112013509.hdf.index': 335987188,
+        'modis/tiles/h12v04/2012337/MCD43A4.A2012337.h12v04.006.2016112013509.hdf.index': -1583910758,
         'modis/tiles/h12v04/2012337/MOD10A1.A2012337.h12v04.005.2012340033542.hdf.index': 1739917027,
         'modis/tiles/h12v04/2012337/MOD11A1.A2012337.h12v04.005.2012339204007.hdf.index': 640817914,
         'modis/tiles/h12v04/2012337/MOD11A2.A2012337.h12v04.005.2012346152330.hdf.index': 53371709,
         'modis/tiles/h12v04/2012337/MYD10A1.A2012337.h12v04.005.2012340112013.hdf.index': 531935583,
         'modis/tiles/h12v04/2012337/MYD11A1.A2012337.h12v04.005.2012341072847.hdf.index': 1676310978,
         'modis/tiles/h12v04/2012337/h12v04_2012337_MCD_fsnow.tif': 297883486,
-        'modis/tiles/h12v04/2012337/h12v04_2012337_MCD_indices.tif': -2140726827,
+        'modis/tiles/h12v04/2012337/h12v04_2012337_MCD_indices.tif': 1828799894,
         'modis/tiles/h12v04/2012337/h12v04_2012337_MCD_snow.tif': -748640537,
         'modis/tiles/h12v04/2012337/h12v04_2012337_MOD-MYD_obstime.tif': -1729084231,
         'modis/tiles/h12v04/2012337/h12v04_2012337_MOD-MYD_temp.tif': -1718009535,
         'modis/tiles/h12v04/2012337/h12v04_2012337_MOD_clouds.tif': -832284681,
-        'modis/tiles/h12v04/2012337/h12v04_2012337_MOD_ndvi8.tif': -593200294,
+        'modis/tiles/h12v04/2012338/MCD43A2.A2012338.h12v04.006.2016112020013.hdf.index': 1475653384,
+        'modis/tiles/h12v04/2012338/MCD43A4.A2012338.h12v04.006.2016112020013.hdf.index': 1671208837,
         'modis/tiles/h12v04/2012338/MOD10A1.A2012338.h12v04.005.2012341091201.hdf.index': 1725484908,
         'modis/tiles/h12v04/2012338/MOD11A1.A2012338.h12v04.005.2012341041222.hdf.index': 838676814,
         'modis/tiles/h12v04/2012338/MYD10A1.A2012338.h12v04.005.2012340142152.hdf.index': -130649785,
         'modis/tiles/h12v04/2012338/MYD11A1.A2012338.h12v04.005.2012341075802.hdf.index': -642783734,
         'modis/tiles/h12v04/2012338/h12v04_2012338_MCD_fsnow.tif': -1930181337,
+        'modis/tiles/h12v04/2012338/h12v04_2012338_MCD_indices.tif': -238333939,
         'modis/tiles/h12v04/2012338/h12v04_2012338_MCD_snow.tif': 387672365,
         'modis/tiles/h12v04/2012338/h12v04_2012338_MOD-MYD_obstime.tif': -1693632983,
         'modis/tiles/h12v04/2012338/h12v04_2012338_MOD-MYD_temp.tif': 1712906003,
@@ -62,13 +81,12 @@ t_process = {
 }
 
 # trailing whitespace and other junk characters are in current output
-t_info = { 'stdout':  """\x1b[1mGIPS Data Repositories (v0.8.2)\x1b[0m
+t_info = { 'stdout':  u"""\x1b[1mGIPS Data Repositories (v0.8.2)\x1b[0m
 \x1b[1m
 Modis Products v1.0.0\x1b[0m
 \x1b[1m
 Terra 8-day Products
-\x1b[0m   ndvi8       Normalized Difference Vegetation Index: 250m
-   temp8td     Surface temperature: 1km                
+\x1b[0m   temp8td     Surface temperature: 1km                
    temp8tn     Surface temperature: 1km                
 \x1b[1m
 Nadir BRDF-Adjusted 16-day Products
@@ -89,23 +107,26 @@ Standard Products
 t_project = { 'created': {
     '0': None, # directory
     '0/2012336_MCD_fsnow.tif': -1883071404,
-    '0/2012336_MOD-MYD_obstime.tif': 1180170371,
+    '0/2012336_MCD_indices.tif': 2002363835,
+    '0/2012336_MCD_quality.tif': -565438400,
     '0/2012336_MCD_snow.tif': -1824464052,
+    '0/2012336_MOD-MYD_obstime.tif': 1180170371,
     '0/2012336_MOD-MYD_temp.tif': 2024858861,
     '0/2012336_MOD_clouds.tif': -1957614367,
     '0/2012337_MCD_fsnow.tif': -856980949,
-    '0/2012337_MCD_indices.tif': -2065700846,
-    '0/2012337_MOD-MYD_obstime.tif': 1283853420,
-    '0/2012337_MCD_quality.tif': 1722910771,
+    '0/2012337_MCD_indices.tif': 1440782578,
+    '0/2012337_MCD_quality.tif': -567163117,
     '0/2012337_MCD_snow.tif': -1690607189,
+    '0/2012337_MOD-MYD_obstime.tif': 1283853420,
     '0/2012337_MOD-MYD_temp.tif': 407802214,
     '0/2012337_MOD_clouds.tif': -415873821,
-    '0/2012337_MOD_ndvi8.tif': -1739368216,
     '0/2012337_MOD_temp8td.tif': 900823219,
     '0/2012337_MOD_temp8tn.tif': -727707878,
     '0/2012338_MCD_fsnow.tif': -1017381876,
-    '0/2012338_MOD-MYD_obstime.tif': -922366135,
+    '0/2012338_MCD_indices.tif': 1865685926,
+    '0/2012338_MCD_quality.tif': -1145887707,
     '0/2012338_MCD_snow.tif': -319441628,
+    '0/2012338_MOD-MYD_obstime.tif': -922366135,
     '0/2012338_MOD-MYD_temp.tif': -869467051,
     '0/2012338_MOD_clouds.tif': 1789735888,
 }}
@@ -115,23 +136,26 @@ t_project_two_runs = t_project
 t_project_no_warp = { 'created': {
     '0': None, # directory
     '0/2012336_MCD_fsnow.tif': -232655043,
-    '0/2012336_MOD-MYD_obstime.tif': -508398437,
+    '0/2012336_MCD_indices.tif': -1993879805,
+    '0/2012336_MCD_quality.tif': 1342857096,
     '0/2012336_MCD_snow.tif': 1704870455,
+    '0/2012336_MOD-MYD_obstime.tif': -508398437,
     '0/2012336_MOD-MYD_temp.tif': -1437591930,
     '0/2012336_MOD_clouds.tif': 792250507,
     '0/2012337_MCD_fsnow.tif': -118176399,
-    '0/2012337_MCD_indices.tif': -517980660,
-    '0/2012337_MOD-MYD_obstime.tif': -266130329,
-    '0/2012337_MCD_quality.tif': -148594234,
+    '0/2012337_MCD_indices.tif': 278320393,
+    '0/2012337_MCD_quality.tif': 1342857096,
     '0/2012337_MCD_snow.tif': -1562861219,
+    '0/2012337_MOD-MYD_obstime.tif': -266130329,
     '0/2012337_MOD-MYD_temp.tif': 125915217,
     '0/2012337_MOD_clouds.tif': 1172608606,
-    '0/2012337_MOD_ndvi8.tif': 1952565287,
     '0/2012337_MOD_temp8td.tif': 2072205290,
     '0/2012337_MOD_temp8tn.tif': -937913415,
     '0/2012338_MCD_fsnow.tif': -50404254,
-    '0/2012338_MOD-MYD_obstime.tif': -1256437319,
+    '0/2012338_MCD_indices.tif': -313489647,
+    '0/2012338_MCD_quality.tif': -429347844,
     '0/2012338_MCD_snow.tif': 415741551,
+    '0/2012338_MOD-MYD_obstime.tif': -1256437319,
     '0/2012338_MOD-MYD_temp.tif': -566077737,
     '0/2012338_MOD_clouds.tif': -1110899594,
 }}
@@ -143,23 +167,26 @@ t_tiles = { 'created': {'h12v04': None}}
 t_tiles_copy = { 'created': {
     'h12v04': None, # directory
     'h12v04/h12v04_2012336_MCD_fsnow.tif': 1284302156,
-    'h12v04/h12v04_2012336_MOD-MYD_obstime.tif': -1094139895,
+    'h12v04/h12v04_2012336_MCD_indices.tif': -83904686,
+    'h12v04/h12v04_2012336_MCD_quality.tif': 1121349116,
     'h12v04/h12v04_2012336_MCD_snow.tif': -2069225181,
+    'h12v04/h12v04_2012336_MOD-MYD_obstime.tif': -1094139895,
     'h12v04/h12v04_2012336_MOD-MYD_temp.tif': -1168080196,
     'h12v04/h12v04_2012336_MOD_clouds.tif': -221229092,
     'h12v04/h12v04_2012337_MCD_fsnow.tif': 1361214837,
-    'h12v04/h12v04_2012337_MCD_indices.tif': 1837681424,
-    'h12v04/h12v04_2012337_MOD-MYD_obstime.tif': -1655167224,
-    'h12v04/h12v04_2012337_MCD_quality.tif': 1493878267,
+    'h12v04/h12v04_2012337_MCD_indices.tif': -404113035,
+    'h12v04/h12v04_2012337_MCD_quality.tif': -1108654,
     'h12v04/h12v04_2012337_MCD_snow.tif': 1201721272,
+    'h12v04/h12v04_2012337_MOD-MYD_obstime.tif': -1655167224,
     'h12v04/h12v04_2012337_MOD-MYD_temp.tif': -746264257,
     'h12v04/h12v04_2012337_MOD_clouds.tif': 1101505794,
-    'h12v04/h12v04_2012337_MOD_ndvi8.tif': 99716648,
     'h12v04/h12v04_2012337_MOD_temp8td.tif': -508252777,
     'h12v04/h12v04_2012337_MOD_temp8tn.tif': 866606587,
     'h12v04/h12v04_2012338_MCD_fsnow.tif': -647359984,
-    'h12v04/h12v04_2012338_MOD-MYD_obstime.tif': -1721291893,
+    'h12v04/h12v04_2012338_MCD_indices.tif': 1437563581,
+    'h12v04/h12v04_2012338_MCD_quality.tif': 1379793143,
     'h12v04/h12v04_2012338_MCD_snow.tif': -1222056036,
+    'h12v04/h12v04_2012338_MOD-MYD_obstime.tif': -1721291893,
     'h12v04/h12v04_2012338_MOD-MYD_temp.tif': 1547257469,
     'h12v04/h12v04_2012338_MOD_clouds.tif': -2052728372,
 }}
@@ -167,12 +194,11 @@ t_tiles_copy = { 'created': {
 t_stats = { 'created': {
     'clouds_stats.txt': -142855826,
     'fsnow_stats.txt': 1649245444,
-    'indices_stats.txt': 551916811,
-    'ndvi8_stats.txt': -1389553863,
+    'indices_stats.txt': 1887478162,
     'obstime_stats.txt': -1289336000,
-    'quality_stats.txt': 41881649,
+    'quality_stats.txt': -914294800,
     'snow_stats.txt': 239300424,
     'temp8td_stats.txt': 2023193464,
     'temp8tn_stats.txt': -1364990917,
-    'temp_stats.txt': -1532103523
+    'temp_stats.txt': -1532103523,
 }}

--- a/gips/test/sys/expected/repo_src_alteration.py
+++ b/gips/test/sys/expected/repo_src_alteration.py
@@ -3,6 +3,8 @@ t_modis_inv_fetch = {
     'created': {
         'modis/tiles/h12v04': None,
         'modis/tiles/h12v04/2012336': None,
+        'modis/tiles/h12v04/2012336/MCD43A2.A2012336.h12v04.006.2016112010833.hdf': 531008224,
+        'modis/tiles/h12v04/2012336/MCD43A4.A2012336.h12v04.006.2016112010833.hdf': -955061246,
         'modis/tiles/h12v04/2012336/MOD10A1.A2012336.h12v04.005.2012339213007.hdf': 1588268768,
         'modis/tiles/h12v04/2012336/MOD11A1.A2012336.h12v04.005.2012339180517.hdf': -868909291,
         'modis/tiles/h12v04/2012336/MYD10A1.A2012336.h12v04.005.2012340031954.hdf': 1810195064,

--- a/gips/test/unit/t_modis_fetch.py
+++ b/gips/test/unit/t_modis_fetch.py
@@ -20,13 +20,13 @@ http_404_params = (
         'http://e4ftl01.cr.usgs.gov/MOLT/MOD11A2.005/2012.12.01'),  # passed to urlopen
 
     (('MCD43A2', 'h12v04', dt(2012, 12, 1, 0, 0)),
-        'http://e4ftl01.cr.usgs.gov/MOTA/MCD43A2.005/2012.12.01'),
+        'http://e4ftl01.cr.usgs.gov/MOTA/MCD43A2.006/2012.12.01'),
 
     (('MOD09Q1', 'h12v04', dt(2012, 12, 1, 0, 0)),
         'http://e4ftl01.cr.usgs.gov/MOLT/MOD09Q1.005//2012.12.01'),
 
     (('MCD43A4', 'h12v04', dt(2012, 12, 1, 0, 0)),
-        'http://e4ftl01.cr.usgs.gov/MOTA/MCD43A4.005/2012.12.01'),
+        'http://e4ftl01.cr.usgs.gov/MOTA/MCD43A4.006/2012.12.01'),
 )
 
 
@@ -65,16 +65,11 @@ def t_no_http_matching_listings(fetch_mocks, call, expected):
 
     modis.modisAsset.fetch(*call)
 
+    # assertions:
     # It should skip the I/O code except for fetching the directory listing
-    uncalled_fns = (response.iter_content, get, open, file.write)
-    readlines = urlopen.return_value.readlines
-    assert not any([f.called for f in uncalled_fns]) and all([
-        readlines.call_count == 1,
-        readlines.call_args  == (),
-        urlopen.call_count   == 1,
-        urlopen.call_args    == ((expected,), {}) # (args, kwargs)
-    ])
-
+    [f.assert_not_called() for f in (response.iter_content, get, open, file.write)]
+    urlopen.return_value.readlines.assert_called_once_with()
+    urlopen.assert_called_once_with(expected)
 
 # VERY truncated snippet of an actual listing file
 MYD11A1_listing = [


### PR DESCRIPTION
This was made by:  `git checkout modis-6 && git rebase -i master HEAD --onto dev`

The diff doesn't look exactly the same as the old PR:

https://github.com/Applied-GeoSolutions/gips/pull/53

@bhbraswell could you read through this and confirm that it looks right?  If there are any problems we can add commits until it's okay.  Likewise I would like to add unit tests.  I also want to confirm system tests still pass, but for that I have to wait on other PRs.
