### PR TITLE
8 error handling

### DIFF
--- a/gips/algorithm.py
+++ b/gips/algorithm.py
@@ -105,5 +105,6 @@ class Algorithm(object):
             alg = cls(**vars(args))
             alg.run_command(**vars(args))
         except Exception, e:
+            # TODO error-handling-fix: use unified high-level error handler
             VerboseOut('Error in %s: %s' % (cls.name, e))
             VerboseOut(traceback.format_exc(), 3)

--- a/gips/atmosphere.py
+++ b/gips/atmosphere.py
@@ -141,6 +141,7 @@ class SIXS():
                     s.run()
                     outputs.append(s.outputs)
         except Exception, e:
+            # TODO error-handling-fix: add existing exception to the new one; see notes for technique AND TROLOLOLOLO
             sys.stdout = stdout
             raise AtmCorrException("Error running 6S: %s" % e)
 
@@ -213,6 +214,7 @@ class MODTRAN():
             self.output = self.readoutput(bandnum)
             VerboseOut('MODTRAN Output: %s' % ' '.join([str(s) for s in self.output]), 4)
         except:
+            # TODO error-handling-fix: add existing exception to the new one; see notes for technique
             VerboseOut(modout, 4)
             raise AtmCorrException("Error running MODTRAN")
 
@@ -224,6 +226,7 @@ class MODTRAN():
         shutil.rmtree(tmpdir)
 
     def readoutput(self, bandnum):
+        # TODO error-handling-fix: this is used once (in this file) sort out what for & refactor as needed (blech)
         try:
             f = open('band' + str(bandnum) + '.chn')
             lines = f.readlines()
@@ -242,6 +245,7 @@ class MODTRAN():
                 # Convert channel radiance to spectral radiance
                 Ld = (float(data[59:72]) * 10000) / bandwidth
             except Exception:
+                # TODO error-handling-fix: confirm this is correct behavior
                 #print 'No downwelled radiance run'
                 Ld = 0.0
             return [trans, Lu, Ld]

--- a/gips/core.py
+++ b/gips/core.py
@@ -154,7 +154,7 @@ class TemporalExtent(object):
             days = days.split(',')
             days = (int(days[0]), int(days[1]))
 
-        with utils.error_handler(msg_prefix='Bad date specification'):
+        with utils.error_handler('Bad date specification'):
             if ',' not in dates:
                 dates = (self._parse_date(dates), self._parse_date(dates, True))
             else:

--- a/gips/core.py
+++ b/gips/core.py
@@ -23,6 +23,7 @@
 
 import datetime
 import calendar
+from gips import utils
 from gips.utils import Colors, open_vector
 
 
@@ -153,14 +154,12 @@ class TemporalExtent(object):
             days = days.split(',')
             days = (int(days[0]), int(days[1]))
 
-        try:
+        with utils.error_handler(msg_prefix='Bad date specification'):
             if ',' not in dates:
                 dates = (self._parse_date(dates), self._parse_date(dates, True))
             else:
                 (d1, d2) = dates.replace(',', ' ').split()
                 dates = (self._parse_date(d1), self._parse_date(d2, True))
-        except ValueError as ve:
-            raise Exception('Bad date specification ({}: {}): {}'.format(type(ve), str(ve), dates))
 
         self.datebounds = dates
         self.daybounds = days

--- a/gips/data/aod/aod.py
+++ b/gips/data/aod/aod.py
@@ -233,6 +233,7 @@ class aodData(Data):
             img = None
             return (val, var)
         except:
+            # TODO error-handling-fix: read through for refactor, otherwise standard handler
             VerboseOut(traceback.format_exc(), 4)
             return (numpy.nan, numpy.nan)
 
@@ -257,6 +258,7 @@ class aodData(Data):
                 aod = numpy.mean(vals[~numpy.isnan(vals)])
                 source = 'MODIS (MOD08_D3) spatial average'
         except Exception:
+            # TODO error-handling-fix: std handler but mind `aod`
             VerboseOut(traceback.format_exc(), 4)
             aod = numpy.nan
 

--- a/gips/data/core.py
+++ b/gips/data/core.py
@@ -889,7 +889,7 @@ class Data(object):
                     if not cls.Asset.discover(t, d, a) or update == True:
                         date_str = d.strftime("%y-%m-%d")
                         msg_prefix = 'Problem fetching asset for {}, {}, {}'.format(a, t, date_str)
-                        with utils.error_handler(continuable=True, msg_prefix=msg_prefix):
+                        with utils.error_handler(msg_prefix, continuable=True):
                             cls.Asset.fetch(a, t, d)
                             # fetched may contain both fetched things and unfetchable things
                             fetched.append((a, t, d))

--- a/gips/data/core.py
+++ b/gips/data/core.py
@@ -248,6 +248,7 @@ class Asset(object):
             else:
                 return [self.filename]
         except Exception as e:
+            # TODO error-handling-fix: use with handler() instead
             raise Exception('Problem accessing asset(s) in {}\n ({})'
                             .format(self.filename, e))
 
@@ -271,6 +272,7 @@ class Asset(object):
                 if not os.path.isdir(fname):
                     os.chmod(fname, 0664)
             except:
+                # TODO error-handling-fix:  continuable handler
                 pass
             extracted_files.append(fname)
         return extracted_files
@@ -357,7 +359,7 @@ class Asset(object):
     @classmethod
     def fetch(cls, asset, tile, date):
         """ Fetch stub """
-        raise Exception("Fetch not supported for this data source")
+        raise NotImplementedError("Fetch not supported for this data source")
 
     @classmethod
     def fetch_ftp(cls, asset, tile, date):
@@ -383,6 +385,7 @@ class Asset(object):
                 ftp.retrbinary('RETR %s' % f, open(os.path.join(cls.Repository.path('stage'), f), "wb").write)
             ftp.close()
         except Exception, e:
+            # TODO error-handling-fix: use with handler() instead
             VerboseOut(traceback.format_exc(), 4)
             raise Exception("Error downloading: %s" % e)
 
@@ -428,6 +431,10 @@ class Asset(object):
             asset = cls(filename)
         except Exception, e:
             # if problem with inspection, move to quarantine
+            # TODO error-handling-fix:
+            #   use verbosity 1 for verbose_outs
+            #   remedial action is needed so keep that
+            #   then re-raise & possibly handle-continuable at higher-level
             VerboseOut(traceback.format_exc(), 3)
             qname = os.path.join(cls.Repository.path('quarantine'), bname)
             if not os.path.exists(qname):
@@ -462,6 +469,7 @@ class Asset(object):
                         try:
                             os.remove(ef.filename)
                         except Exception as e:
+                            # TODO error-handling-fix: use with handler() instead
                             raise Exception('Unable to remove old version {}'
                                             .format(ef.filename))
                     files = glob.glob(os.path.join(tpath, '*'))
@@ -469,6 +477,7 @@ class Asset(object):
                         for f in set(files).difference([ef.filename]):
                             os.remove(f)
                     except OSError as exc:
+                        # TODO error-handling-fix: use with handler() instead
                         VerboseOut('Unable to remove all products from {}'
                                    .format(tpath))
                     try:
@@ -477,11 +486,13 @@ class Asset(object):
                         VerboseOut(bname + ' -> ' + newfilename, 2)
                         numlinks = numlinks + 1
                     except Exception, e:
+                        # TODO error-handling-fix: use with handler() instead
                         VerboseOut(traceback.format_exc(), 3)
                         raise Exception('Problem adding {} to archive: {}'
                                         .format(filename, e))
                 else:
                     # 'normal' case:  Just add the asset to the archive; no other work needed
+                    # TODO error-handling-fix: refactor this whole clause
                     try:
                         os.makedirs(tpath)
                     except OSError as exc:
@@ -534,7 +545,18 @@ class Data(object):
         pass
 
     def copy(self, dout, products, site=None, res=None, interpolation=0, crop=False, overwrite=False, tree=False):
-        """ Copy products to new directory, warp to projection if given site """
+        """ Copy products to new directory, warp to projection if given site.
+
+        Arguments
+        =========
+        dout:       output or destination directory; mkdir(dout) is done if needed.
+        products:   which products to copy (passed to self.RequestedProducts())
+
+
+        """
+        # TODO error-handling-fix: only caller of this method seems to be:
+        # gips/scripts/tiles.py:69:  inv[date].tiles[tid].copy(tld, args.products, inv.spatial.site,
+        # so refactor away?  Or otherwise attempt to simplify
         # TODO - allow hard and soft linking options
         if res is None:
             res = self.Asset._defaultresolution
@@ -709,6 +731,7 @@ class Data(object):
                 self.AddFile(sensor, product, f, add_to_db=False)
             except Exception:
                 # This was just a bad file
+                # TODO error-handling-fix: use continuable handler
                 VerboseOut('Unrecognizable file: %s' % f, 3)
                 continue
 
@@ -748,6 +771,7 @@ class Data(object):
             return gippy.GeoImage(fname)
 
         except Exception as e:
+            # TODO error-handling-fix: use with handler() instead
             raise Exception('error reading product (%s, %s, %s)' % (sensor, product, e))
 
     def open_assets(self, product):
@@ -813,6 +837,7 @@ class Data(object):
                         datetime.strptime(parts[len(parts) - 3], datedir)
                         files.append(f)
                     except:
+                        # TODO error-handling-fix: continuable handler
                         pass
 
         datas = []

--- a/gips/data/core.py
+++ b/gips/data/core.py
@@ -93,8 +93,7 @@ class Repository(object):
     def find_dates(cls, tile):
         """ Get list of dates available in repository for a tile """
         if orm.use_orm():
-            with orm.std_error_handler():
-                return dbinv.list_dates(cls.name.lower(), tile)
+            return dbinv.list_dates(cls.name.lower(), tile)
         tdir = cls.data_path(tile=tile)
         if os.path.exists(tdir):
             return sorted([datetime.strptime(os.path.basename(d), cls._datedir).date() for d in os.listdir(tdir)])
@@ -298,9 +297,8 @@ class Asset(object):
         if asset is not None:
             criteria['asset'] = asset
         if orm.use_orm():
-            with orm.std_error_handler():
-                # search for ORM Assets to use for making GIPS Assets
-                return [cls(a.name) for a in dbinv.asset_search(**criteria)]
+            # search for ORM Assets to use for making GIPS Assets
+            return [cls(a.name) for a in dbinv.asset_search(**criteria)]
 
         # The rest of this fn uses the filesystem inventory
         tpath = cls.Repository.data_path(tile, date)
@@ -745,9 +743,8 @@ class Data(object):
         # TODO - currently assumes single sensor for each product
         self.sensors[product] = sensor
         if add_to_db and orm.use_orm(): # update inventory DB if such is requested
-            with orm.std_error_handler():
-                dbinv.update_or_add_product(driver=self.name.lower(), product=product, sensor=sensor,
-                                            tile=self.id, date=self.date, name=filename)
+            dbinv.update_or_add_product(driver=self.name.lower(), product=product, sensor=sensor,
+                                        tile=self.id, date=self.date, name=filename)
 
 
 

--- a/gips/data/core.py
+++ b/gips/data/core.py
@@ -40,6 +40,7 @@ import gippy
 from gippy.algorithms import CookieCutter
 from gips import __version__
 from gips.utils import settings, VerboseOut, RemoveFiles, File2List, List2File, Colors, basename, mkdir, open_vector
+from gips import utils
 from ..inventory import dbinv, orm
 
 from pdb import set_trace
@@ -85,8 +86,7 @@ class Repository(object):
     def find_tiles(cls):
         """Get list of all available tiles for the current driver."""
         if orm.use_orm():
-            with orm.std_error_handler():
-                return dbinv.list_tiles(cls.name.lower())
+            return dbinv.list_tiles(cls.name.lower())
         return os.listdir(cls.path('tiles'))
 
     @classmethod
@@ -862,13 +862,12 @@ class Data(object):
                 for d in asset_dates:
                     # if we don't have it already, or if update (force) flag
                     if not cls.Asset.discover(t, d, a) or update == True:
-                        try:
+                        date_str = d.strftime("%y-%m-%d")
+                        msg_prefix = 'Problem fetching asset for {}, {}, {}'.format(a, t, date_str)
+                        with utils.error_handler(continuable=True, msg_prefix=msg_prefix):
                             cls.Asset.fetch(a, t, d)
                             # fetched may contain both fetched things and unfetchable things
                             fetched.append((a, t, d))
-                        except Exception, e:
-                            VerboseOut(traceback.format_exc(), 4)
-                            VerboseOut('Problem fetching asset: %s' % e, 3)
         return fetched
 
     @classmethod

--- a/gips/data/landsat/landsat.py
+++ b/gips/data/landsat/landsat.py
@@ -515,6 +515,7 @@ class landsatData(Data):
             try:
                 img = self._readraw()
             except Exception, e:
+                # TODO error-handling-fix: with handler
                 VerboseOut(traceback.format_exc(), 5)
                 raise Exception('Error reading %s: %s' % (basename(self.assets['DN'].filename), e))
 
@@ -539,6 +540,7 @@ class landsatData(Data):
                     md["AOD Source"] = str(atm6s.aod[0])
                     md["AOD Value"] = str(atm6s.aod[1])
                 except Exception, e:
+                    # TODO error-handling-fix: with handler
                     VerboseOut(traceback.format_exc(), 4)
                     raise Exception('Problem running 6S atmospheric model: %s' % e)
 
@@ -573,6 +575,7 @@ class landsatData(Data):
                             dilation = int(val[2]) if len(val) > 2 else 10
                             cloudheight = int(val[3]) if len(val) > 3 else 4000
                         except:
+                            # TODO error-handling-fix: refactor; no try-except needed
                             erosion = 5
                             dilation = 10
                             cloudheight = 4000
@@ -593,6 +596,7 @@ class landsatData(Data):
                             tolerance = int(val[1]) if len(val) > 1 else 3
                             dilation = int(val[2]) if len(val) > 2 else 5
                         except:
+                            # TODO error-handling-fix: refactor; no try-except needed
                             tolerance = 3
                             dilation = 5
                         imgout = Fmask(reflimg, fname, tolerance, dilation)
@@ -733,6 +737,7 @@ class landsatData(Data):
                             dilation = int(val[2]) if len(val) > 2 else 10
                             cloudheight = int(val[3]) if len(val) > 3 else 4000
                         except:
+                            # TODO error-handling-fix: refactor; no try-except needed
                             erosion = 5
                             dilation = 10
                             cloudheight = 4000
@@ -749,6 +754,7 @@ class landsatData(Data):
                     self.AddFile(sensor, key, fname)
                     VerboseOut(' -> %s: processed in %s' % (os.path.basename(fname), datetime.now() - start), 1)
                 except Exception, e:
+                    # TODO error-handling-fix: continuable handler
                     VerboseOut('Error creating product %s for %s: %s' % (key, basename(self.assets['DN'].filename), e), 2)
                     VerboseOut(traceback.format_exc(), 3)
 
@@ -788,6 +794,7 @@ class landsatData(Data):
                             RemoveFiles(files)
                 shutil.rmtree(os.path.join(self.path, 'modtran'))
             except:
+                # TODO error-handling-fix: continuable handler
                 # VerboseOut(traceback.format_exc(), 4)
                 pass
 
@@ -827,6 +834,7 @@ class landsatData(Data):
         try:
             text = open(mtlfilename, 'r').read()
         except IOError as e:
+            # TODO error-handling-fix: with handler
             raise Exception('({})'.format(e))
         if len(text) < 10:
             raise Exception('MTL file is too short. {}'.format(mtlfilename))
@@ -872,6 +880,7 @@ class landsatData(Data):
         try:
             clouds = float(mtl['CLOUD_COVER'])
         except:
+            # TODO error-handling-fix: no try-except needed
             clouds = 0
 
         filenames = []
@@ -900,6 +909,7 @@ class landsatData(Data):
         try:
             qafilename = [f for f in datafiles if '_BQA.TIF' in f][0]
         except Exception:
+            # TODO error-handling-fix: no try-except needed
             qafilename = None
 
         self.metadata = {

--- a/gips/data/landsat/landsat.py
+++ b/gips/data/landsat/landsat.py
@@ -39,6 +39,7 @@ from gippy.algorithms import ACCA, Fmask, LinearTransform, Indices, AddShadowMas
 from gips.data.core import Repository, Asset, Data
 from gips.atmosphere import SIXS, MODTRAN
 from gips.utils import VerboseOut, RemoveFiles, basename, settings
+from gips import utils
 
 from landsat_util import search, downloader
 
@@ -512,12 +513,8 @@ class landsatData(Data):
             self.basename = self.basename + '_' + self.sensors[asset]
 
             # Read the assets
-            try:
+            with utils.error_handler('Error reading ' + basename(self.assets['DN'].filename)):
                 img = self._readraw()
-            except Exception, e:
-                # TODO error-handling-fix: with handler
-                VerboseOut(traceback.format_exc(), 5)
-                raise Exception('Error reading %s: %s' % (basename(self.assets['DN'].filename), e))
 
             meta = self.assets['DN'].meta
             visbands = self.assets['DN'].visbands
@@ -533,16 +530,12 @@ class landsatData(Data):
 
                 if not settings().REPOS[self.Repository.name.lower()]['6S']:
                     raise Exception('6S is required for atmospheric correction')
-                try:
+                with utils.error_handler('Problem running 6S atmospheric model'):
                     wvlens = [(meta[b]['wvlen1'], meta[b]['wvlen2']) for b in visbands]
                     geo = self.metadata['geometry']
                     atm6s = SIXS(visbands, wvlens, geo, self.metadata['datetime'], sensor=self.sensor_set[0])
                     md["AOD Source"] = str(atm6s.aod[0])
                     md["AOD Value"] = str(atm6s.aod[1])
-                except Exception, e:
-                    # TODO error-handling-fix: with handler
-                    VerboseOut(traceback.format_exc(), 4)
-                    raise Exception('Problem running 6S atmospheric model: %s' % e)
 
             # Break down by group
             groups = products.groups()
@@ -565,7 +558,9 @@ class landsatData(Data):
                 # TODO - update if no atmos desired for others
                 toa = self._products[val[0]].get('toa', False) or 'toa' in val
                 # Create product
-                try:
+                with utils.error_handler('Error creating product {} for {}'.format(
+                                                key, basename(self.assets['DN'].filename),
+                                         continuable=True)):
                     fname = os.path.join(self.path, self.basename + '_' + key)
                     if val[0] == 'acca':
                         s_azim = self.metadata['geometry']['solarazimuth']
@@ -753,10 +748,6 @@ class landsatData(Data):
                     imgout = None
                     self.AddFile(sensor, key, fname)
                     VerboseOut(' -> %s: processed in %s' % (os.path.basename(fname), datetime.now() - start), 1)
-                except Exception, e:
-                    # TODO error-handling-fix: continuable handler
-                    VerboseOut('Error creating product %s for %s: %s' % (key, basename(self.assets['DN'].filename), e), 2)
-                    VerboseOut(traceback.format_exc(), 3)
 
             # Process Indices
             indices0 = dict(groups['Index'], **groups['Tillage'])
@@ -831,14 +822,10 @@ class landsatData(Data):
         if not os.path.exists(mtlfilename):
             mtlfilename = self.assets['DN'].extract([mtlfilename])[0]
         # Read MTL file
-        try:
+        with utils.error_handler('Error reading metadata file ' + mtlfilename):
             text = open(mtlfilename, 'r').read()
-        except IOError as e:
-            # TODO error-handling-fix: with handler
-            raise Exception('({})'.format(e))
         if len(text) < 10:
             raise Exception('MTL file is too short. {}'.format(mtlfilename))
-
 
         sensor = self.assets['DN'].sensor
         smeta = self.assets['DN']._sensors[sensor]

--- a/gips/data/merra/merra.py
+++ b/gips/data/merra/merra.py
@@ -241,8 +241,10 @@ class merraAsset(Asset):
                 with Timeout(30):
                     dataset = open_url(loc)
             except Timeout.Timeout:
+                # change to verbose_out()
                 print "Timeout"
             except Exception,e:
+                # TODO error-handling-fix: refactor the whole method to use sensible error reporting
                 pass
             else:
                 success = True
@@ -278,6 +280,8 @@ class merraAsset(Asset):
         try:
             dataset = cls.opendap_fetch(asset, date)
         except Exception:
+            # TODO error-handling-fix:  permit this exception to bubble up; 
+            # use continuable handler in caller
             print "Fetch: data not available", asset, tile, date
             return
 
@@ -477,6 +481,7 @@ class merraData(Data):
             try:
                 assets = self.asset_filenames(val[0])
             except:
+                # TODO error-handling-fix: leave as literal try-except but report on error
                 # Required assets unavailable, continue to next product
                 continue
             fout = os.path.join(self.path, self.basename + "_merra_" + key)

--- a/gips/data/merra/raster.py
+++ b/gips/data/merra/raster.py
@@ -7,6 +7,7 @@ def write_raster(fname, data, proj, geo, meta, bandnames=[], gcps=None, nodata=N
     try:
         (nband, ny, nx) = data.shape
     except:
+        # TODO error-handling-fix: leave as-is but report the error
         nband = 1
         (ny, nx) = data.shape
         data = data.reshape(1, ny, nx)

--- a/gips/data/modis/modis.py
+++ b/gips/data/modis/modis.py
@@ -344,10 +344,14 @@ class modisData(Data):
             versions = {}
 
             for asset in assets:
+                # many asset types won't be found for the current date/spatial constraint
+                if asset not in self.assets:
+                    missingassets.append(asset)
+                    continue
                 try:
                     sds = self.assets[asset].datafiles()
-                except Exception:
-                    # TODO error-handling-fix: leave as literal try-except but add standard reporting
+                except Exception as e:
+                    utils.report_error(e, 'Error reading datafiles for ' + asset)
                     missingassets.append(asset)
                 else:
                     availassets.append(asset)
@@ -870,14 +874,10 @@ class modisData(Data):
                     hournodatavalue = hourbands[iband].NoDataValue()
                     hour = hourbands[iband].Read()
                     hour = hour[hour != hournodatavalue]
-                    try:
-                        #hourmin = hour.min()
+                    hourmean = 0
+                    with utils.error_handler("Couldn't compute hour mean for " + fname,
+                                             continuable=True):
                         hourmean = hour.mean()
-                        #hourmax = hour.max()
-                        # print "hour.min(), hour.mean(), hour.max()", hour.min(), hour.mean(), hour.max()
-                    except:
-                        # TODO error-handling-fix:  use 0 as default value above continuable handler
-                        hourmean = 0
 
                     metaname = "MEANOVERPASSTIME_%s_%s" % (dayornight, platform)
                     metaname = metaname.upper()

--- a/gips/data/modis/modis.py
+++ b/gips/data/modis/modis.py
@@ -347,6 +347,7 @@ class modisData(Data):
                 try:
                     sds = self.assets[asset].datafiles()
                 except Exception:
+                    # TODO error-handling-fix: leave as literal try-except but add standard reporting
                     missingassets.append(asset)
                 else:
                     availassets.append(asset)
@@ -875,6 +876,7 @@ class modisData(Data):
                         #hourmax = hour.max()
                         # print "hour.min(), hour.mean(), hour.max()", hour.min(), hour.mean(), hour.max()
                     except:
+                        # TODO error-handling-fix:  use 0 as default value above continuable handler
                         hourmean = 0
 
                     metaname = "MEANOVERPASSTIME_%s_%s" % (dayornight, platform)

--- a/gips/data/modis/modis.py
+++ b/gips/data/modis/modis.py
@@ -39,6 +39,7 @@ import gippy
 from gippy.algorithms import Indices
 from gips.data.core import Repository, Asset, Data
 from gips.utils import VerboseOut, settings
+from gips import utils
 
 from pdb import set_trace
 
@@ -197,11 +198,12 @@ class modisAsset(Asset):
         pattern = '(%s.A%s%s.%s.\d{3}.\d{13}.hdf)' % (asset, str(year), str(date.timetuple()[7]).zfill(3), tile)
         cpattern = re.compile(pattern)
 
-        try:
+        if datetime.datetime.today().date().weekday() == 2:
+            err_msg = "Error downloading on a Wednesday; possible planned MODIS provider downtime"
+        else:
+            err_msg = "Error downloading"
+        with utils.error_handler(err_msg):
             listing = urllib.urlopen(mainurl).readlines()
-        except Exception:
-            # MODIS servers do maintenance on wednesday
-            raise Exception("Unable to access %s --- is it Wednesday?" % mainurl)
 
         success = False
         for item in listing:
@@ -215,7 +217,7 @@ class modisAsset(Asset):
                 url = ''.join([mainurl, '/', name])
                 outpath = os.path.join(cls.Repository.path('stage'), name)
 
-                try:
+                with utils.error_handler(continuable=True, err_msg="Asset fetch error"):
                     # tinkering:
                     # chunk size & stream=True in req
                     # cookies / cache auth
@@ -239,19 +241,10 @@ class modisAsset(Asset):
                         with open(outpath, 'wb') as fd:
                             for chunk in response.iter_content():
                                 fd.write(chunk)
-
-                except Exception:
-                    # TODO - implement pre-check to only attempt on valid dates
-                    # then uncomment this
-                    #raise Exception('Unable to retrieve %s from %s' % (name, url))
-                    pass
-                else:
-                    VerboseOut('Retrieved %s' % name, 2)
+                    utils.verbose_out('Retrieved %s' % name, 2)
                     success = True
 
         if not success:
-            # TODO - implement pre-check to only attempt on valid dates then uncomment below
-            #raise Exception('Unable to find remote match for %s at %s' % (pattern, mainurl))
             VerboseOut('Unable to find remote match for %s at %s' % (pattern, mainurl), 4)
 
     def updated(self, newasset):

--- a/gips/data/modis/modis.py
+++ b/gips/data/modis/modis.py
@@ -217,7 +217,7 @@ class modisAsset(Asset):
                 url = ''.join([mainurl, '/', name])
                 outpath = os.path.join(cls.Repository.path('stage'), name)
 
-                with utils.error_handler(continuable=True, err_msg="Asset fetch error"):
+                with utils.error_handler("Asset fetch error", continuable=True):
                     # tinkering:
                     # chunk size & stream=True in req
                     # cookies / cache auth

--- a/gips/data/prism/prism.py
+++ b/gips/data/prism/prism.py
@@ -129,12 +129,14 @@ class prismAsset(Asset):
                 ftp.retrbinary('RETR %s' % filename, ofile.write)
             ftp.close()
         except Exception, e:
+            # TODO error-handling-fix: with handler BUT mind the else
             raise Exception("Error downloading: %s" % e)
         else:
             assets = cls.archive(stagedir)
         try:
             os.remove(ofilename)
         except OSError as ose:
+            # TODO error-handling-fix: change to 'raise'
             if ose.errno != 2:
                 raise ose
         os.rmdir(stagedir)
@@ -245,6 +247,7 @@ class prismData(Data):
                 try:
                     bil = get_bil_file(self, asset)
                 except KeyError:
+                    # TODO error-handling-fix: this doesn't have to be a try/except; use a conditional
                     missingassets.append(asset)
                 else:
                     availassets.append(asset)
@@ -268,6 +271,9 @@ class prismData(Data):
                 try:
                     lag = int(val[1])
                 except ValueError, TypeError:
+                    # TODO error-handling-fix:
+                    #   refactor IndexError to be a conditional
+                    #   use with handler for other types
                     raise Exception(
                         'pptsum argument format error (given: {}).'
                     )

--- a/gips/data/sarannual/sarannual.py
+++ b/gips/data/sarannual/sarannual.py
@@ -136,6 +136,7 @@ class sarannualData(Data):
             try:
                 datafiles = self.assets[asset].extract()
             except:
+                # TODO error-handling-fix: put `continue` in conditional; use with handler
                 VerboseOut("Asset %s doesn't exist for tile %s" % (asset, self.id), 3)
                 continue
             if val[0] == 'sign':

--- a/gips/data/weld/weld.py
+++ b/gips/data/weld/weld.py
@@ -101,6 +101,7 @@ class weldAsset(Asset):
         try:
             listing = urllib.urlopen(mainurl).readlines()
         except Exception:
+            # TODO error-handling-fix: standard handle
             raise Exception("Unable to access %s" % mainurl)
         pattern = '(%s.week\d{2}.%s.%s.doy\d{3}to\d{3}.v1.5.hdf)' % (asset, str(year), tile)
         cpattern = re.compile(pattern)
@@ -120,6 +121,7 @@ class weldAsset(Asset):
                     output.write(connection.read())
                     output.close()
                 except Exception:
+                    # TODO error-handling-fix: continuable handler but mind the else
                     # TODO - implement pre-check to only attempt on valid dates
                     # then uncomment this
                     #raise Exception('Unable to retrieve %s from %s' % (name, url))
@@ -179,6 +181,7 @@ class weldData(Data):
                 try:
                     sds = self.assets[asset].datafiles()
                 except Exception:
+                    # TODO error-handling-fix: continuable handler but mind the else
                     missingassets.append(asset)
                 else:
                     availassets.append(asset)

--- a/gips/inventory/__init__.py
+++ b/gips/inventory/__init__.py
@@ -109,9 +109,11 @@ class Inventory(object):
         print Colors.BOLD + '\nSENSORS' + Colors.OFF
         for key in sorted(self.sensor_set):
             try:
+                # revise but leave in place
                 desc = self.dataclass.Asset._sensors[key]['description']
                 scode = key + ': ' if key != '' else ''
             except:
+                # TODO error-handling-fix: no exception needed here
                 desc = ''
                 scode = key
             print self.color(key) + '%s%s' % (scode, desc) + Colors.OFF
@@ -143,6 +145,7 @@ class ProjectInventory(Inventory):
             self.requested_products = products
             self.sensors = sensor_set
         except:
+            # TODO error-handling-fix: with handler
             VerboseOut(traceback.format_exc(), 4)
             raise Exception("%s does not appear to be a GIPS project directory" % self.projdir)
 
@@ -210,6 +213,7 @@ class ProjectInventory(Inventory):
                 try:
                     filepaths[date][product] = self.data[date][product]
                 except:
+                    # TODO error-handling-fix: no exception needed
                     filepaths[date] = {product: self.data[date][product]}
         return filepaths
 
@@ -344,6 +348,7 @@ class DataInventory(Inventory):
                 try:
                     self.data[date].process(*args, **kwargs)
                 except:
+                    # TODO error-handling-fix: continuable handler
                     VerboseOut(traceback.format_exc(), 4)
         if len(self.products.composite) > 0:
             self.dataclass.process_composites(self, self.products.composite, **kwargs)
@@ -362,6 +367,7 @@ class DataInventory(Inventory):
         for d in self.dates:
             if tree:
                 dout = os.path.join(datadir, d.strftime('%Y%j'))
+            # TODO error-handling-fix: handle tiles.Tiles.mosaic exception here
             self.data[d].mosaic(dout, **kwargs)
 
         VerboseOut('Completed mosaic project in %s' % (dt.now() - start), 2)

--- a/gips/inventory/__init__.py
+++ b/gips/inventory/__init__.py
@@ -103,19 +103,6 @@ class Inventory(object):
             oldyear = date.year
         if self.numfiles != 0:
             VerboseOut("\n\n%s files on %s dates" % (self.numfiles, len(self.dates)), 1)
-            self.print_legend()
-
-    def print_legend(self):
-        print Colors.BOLD + '\nSENSORS' + Colors.OFF
-        _sensors = self.dataclass.Asset._sensors
-        for key in sorted(self.sensor_set):
-            if key in _sensors:
-                desc = _sensors[key]['description']
-                scode = key + ': ' if key != '' else ''
-            else:
-                desc = ''
-                scode = key
-            print self.color(key) + '%s%s' % (scode, desc) + Colors.OFF
 
 
 class ProjectInventory(Inventory):
@@ -367,4 +354,16 @@ class DataInventory(Inventory):
             if len(self.spatial.tiles) > 1:
                 raise RuntimeError('Expected 1 tile but got ' + repr(self.spatial.tiles))
             print Colors.BOLD + 'Asset Holdings for tile ' + self.spatial.tiles[0] + Colors.OFF
+
         super(DataInventory, self).pprint(**kwargs)
+
+        print Colors.BOLD + '\nSENSORS' + Colors.OFF
+        _sensors = self.dataclass.Asset._sensors
+        for key in sorted(self.sensor_set):
+            if key in _sensors:
+                desc = _sensors[key]['description']
+                scode = key + ': ' if key != '' else ''
+            else:
+                desc = ''
+                scode = key
+            print self.color(key) + '%s%s' % (scode, desc) + Colors.OFF

--- a/gips/inventory/orm/__init__.py
+++ b/gips/inventory/orm/__init__.py
@@ -4,21 +4,7 @@ import traceback
 
 import django
 
-from gips.utils import verbose_out
-
-
-# TODO probably deprecate and delete
-@contextmanager
-def std_error_handler():
-    """Handle problems with ORM code in a unified way."""
-    try:
-        yield
-    except Exception as e:
-        # TODO error-handling-fix: remove this after removing all its users
-        verbose_out(traceback.format_exc(), 4, sys.stderr)
-        verbose_out("Error processing database inventory: {}".format(e.message), 1, sys.stderr)
-        # no exit here, raise it!
-        sys.exit(1)
+from gips.utils import verbose_out, error_handler
 
 
 def use_orm():
@@ -53,7 +39,7 @@ def setup():
             msg = ("Inventory database does not support '{}'.  "
                    "Set GIPS_ORM=false to use the filesystem inventory instead.")
             raise Exception(msg.format(driver_for_dbinv_feature_toggle))
-        with std_error_handler():
+        with error_handler("Error initializing Django ORM"):
             os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gips.inventory.orm.settings")
             django.setup()
     setup_complete = True

--- a/gips/inventory/orm/__init__.py
+++ b/gips/inventory/orm/__init__.py
@@ -7,6 +7,7 @@ import django
 from gips.utils import verbose_out
 
 
+# TODO probably deprecate and delete
 @contextmanager
 def std_error_handler():
     """Handle problems with ORM code in a unified way."""

--- a/gips/inventory/orm/__init__.py
+++ b/gips/inventory/orm/__init__.py
@@ -14,8 +14,10 @@ def std_error_handler():
     try:
         yield
     except Exception as e:
+        # TODO error-handling-fix: remove this after removing all its users
         verbose_out(traceback.format_exc(), 4, sys.stderr)
         verbose_out("Error processing database inventory: {}".format(e.message), 1, sys.stderr)
+        # no exit here, raise it!
         sys.exit(1)
 
 

--- a/gips/parsers.py
+++ b/gips/parsers.py
@@ -31,11 +31,13 @@ import gippy
 class GIPSParser(argparse.ArgumentParser):
     """ Extends argparser parser to print help on error """
 
-    def __init__(self, datasources=True, **kwargs):
+    def __init__(self, datasources=True, with_default=True, **kwargs):
         super(GIPSParser, self).__init__(**kwargs)
         self.datasources = datasources
         self.formatter_class = argparse.ArgumentDefaultsHelpFormatter
         self.parent_parsers = []
+        if with_default:
+            self.add_default_parser()
 
     def parse_args(self, **kwargs):
         if self.datasources:
@@ -55,18 +57,20 @@ class GIPSParser(argparse.ArgumentParser):
     def add_default_parser(self):
         """ This adds a parser with default options """
         if self.datasources:
-            parser = GIPSParser(add_help=False)
+            parser = GIPSParser(add_help=False, with_default=False)
         else:
             parser = self
-        parser.add_argument('-v', '--verbose', help='Verbosity - 0: quiet, 1: normal, 2: debug',
+        parser.add_argument('-v', '--verbose', help='Verbosity - 0: quiet, 1: normal, 2+: debug',
                             default=1, type=int)
+        parser.add_argument('--stop-on-error', default=False, action='store_true',
+                            help='Do not attempt to continue execution after errors')
         self.parent_parsers.append(parser)
         return parser
 
     def add_inventory_parser(self, site_required=False):
         """ This adds a parser with inventory options """
         if self.datasources:
-            parser = GIPSParser(add_help=False)
+            parser = GIPSParser(add_help=False, with_default=False)
         else:
             parser = self
         group = parser.add_argument_group('inventory options')
@@ -81,10 +85,10 @@ class GIPSParser(argparse.ArgumentParser):
         group.add_argument('--sensors', help='Sensors to include', nargs='*', default=None)
         group.add_argument('--%cov', dest='pcov', help='Threshold of %% tile coverage over site', default=0, type=int)
         group.add_argument('--%tile', dest='ptile', help='Threshold of %% tile used', default=0, type=int)
-        group.add_argument('--fetch', help='Fetch any missing data (if supported)', default=False, action='store_true')
+        group.add_argument('--fetch', help='Fetch any missing data (if supported)',
+                           default=False, action='store_true')
         group.add_argument('--update', help='Force fetch and/ or update data (if supported)', default=False, action='store_true')
 
-        group.add_argument('-v', '--verbose', help='Verbosity - 0: quiet, 1: normal, 2: debug', default=1, type=int)
         group.add_argument('-p', '--products', help='Requested Products', nargs='*')
         self.parent_parsers.append(parser)
         return parser
@@ -92,7 +96,7 @@ class GIPSParser(argparse.ArgumentParser):
     def add_process_parser(self):
         """ This adds a parser with processing options """
         if self.datasources:
-            parser = GIPSParser(add_help=False)
+            parser = GIPSParser(add_help=False, with_default=False)
         else:
             parser = self
         group = parser.add_argument_group('processing options')
@@ -111,7 +115,7 @@ class GIPSParser(argparse.ArgumentParser):
     def add_project_parser(self):
         """ This adds a parser with project options """
         if self.datasources:
-            parser = GIPSParser(add_help=False)
+            parser = GIPSParser(add_help=False, with_default=False)
         else:
             parser = self
         group = parser.add_argument_group('project directory options')
@@ -128,7 +132,7 @@ class GIPSParser(argparse.ArgumentParser):
     def add_warp_parser(self):
         """ This adds a parser with warping options """
         if self.datasources:
-            parser = GIPSParser(add_help=False)
+            parser = GIPSParser(add_help=False, with_default=False)
         else:
             parser = self
         group = parser.add_argument_group('warp options')
@@ -147,7 +151,7 @@ class GIPSParser(argparse.ArgumentParser):
     def add_projdir_parser(self):
         """ This adds a parser with options for reading a project output directory """
         if self.datasources:
-            parser = GIPSParser(add_help=False)
+            parser = GIPSParser(add_help=False, with_default=False)
         else:
             parser = self
         group = parser.add_argument_group('input project options')

--- a/gips/parsers.py
+++ b/gips/parsers.py
@@ -24,7 +24,7 @@
 import sys
 import argparse
 
-from gips.utils import data_sources
+from gips.utils import data_sources, verbose_out
 import gippy
 
 
@@ -163,7 +163,10 @@ class GIPSParser(argparse.ArgumentParser):
     def add_data_sources(self):
         """ Adds data sources to parser """
         subparser = self.add_subparsers(dest='command')
-        for src, desc in data_sources().items():
+        sources = data_sources()
+        if len(sources) == 0:
+            verbose_out("There are no available data sources!", 1, sys.stderr)
+        for src, desc in sources.items():
             subparser.add_parser(src, help=desc, parents=self.parent_parsers)
 
 

--- a/gips/scripts/archive.py
+++ b/gips/scripts/archive.py
@@ -59,6 +59,7 @@ def main():
                                               name=a.archived_filename, driver=cls.name.lower())
 
     except Exception, e:
+        # TODO error-handling-fix: standard script-level handler
         import traceback
         VerboseOut(traceback.format_exc(), 4)
         print 'Data archive error: %s' % e

--- a/gips/scripts/archive.py
+++ b/gips/scripts/archive.py
@@ -53,10 +53,9 @@ def main():
 
         # if DB inventory is enabled, update it to contain the newly archived assets
         if orm.use_orm():
-            with orm.std_error_handler():
-                for a in archived_assets:
-                    dbinv.update_or_add_asset(asset=a.asset, sensor=a.sensor, tile=a.tile, date=a.date,
-                                              name=a.archived_filename, driver=cls.name.lower())
+            for a in archived_assets:
+                dbinv.update_or_add_asset(asset=a.asset, sensor=a.sensor, tile=a.tile, date=a.date,
+                                          name=a.archived_filename, driver=cls.name.lower())
 
     except Exception, e:
         # TODO error-handling-fix: standard script-level handler

--- a/gips/scripts/config.py
+++ b/gips/scripts/config.py
@@ -72,6 +72,7 @@ def main():
                     print v
                     exec('pprint.pprint(s.%s)' % v)
         except Exception as e:
+            # TODO error-handling-fix: standard script-level handler
             # print traceback.format_exc()
             print 'Unable to access settings: {}'.format(e)
             sys.exit(1)
@@ -84,6 +85,7 @@ def main():
             create_repos()
             migrate_database()
         except Exception, e:
+            # TODO error-handling-fix: standard script-level handler
             print traceback.format_exc()
             print 'Could not create environment settings: %s' % e
             sys.exit(1)
@@ -94,6 +96,7 @@ def main():
             import gips.settings
             cfgfile = create_user_settings()
         except ImportError:
+            # TODO error-handling-fix: standard script-level handler
             print 'Could not create user settings: %s' % e
 
         try:
@@ -102,6 +105,7 @@ def main():
             create_repos()
             migrate_database()
         except Exception as e:
+            # TODO error-handling-fix: standard script-level handler
             print traceback.format_exc()
             print 'Could not create repository directories'
             sys.exit(1)

--- a/gips/scripts/config.py
+++ b/gips/scripts/config.py
@@ -41,8 +41,7 @@ def migrate_database():
         return
     print 'Migrating database'
     orm.setup()
-    with orm.std_error_handler():
-        call_command('migrate', interactive=False)
+    call_command('migrate', interactive=False)
 
 
 def main():

--- a/gips/scripts/info.py
+++ b/gips/scripts/info.py
@@ -24,6 +24,7 @@
 from gips import __version__ as gipsversion
 from gips.parsers import GIPSParser
 from gips.utils import Colors, VerboseOut, import_data_class
+from gips import utils
 
 
 def main():
@@ -33,6 +34,9 @@ def main():
     try:
         parser = GIPSParser(description=title)
         args = parser.parse_args()
+
+        cls = utils.gips_script_setup(args.command, args.stop_on_error)
+
         print title
         cls = import_data_class(args.command)
         cls.print_products()
@@ -41,6 +45,8 @@ def main():
         import traceback
         VerboseOut(traceback.format_exc(), 4)
         print 'GIPS Data Repository error: %s' % e
+
+    utils.gips_exit() # produce a summary error report then quit with a proper exit status
 
 
 if __name__ == "__main__":

--- a/gips/scripts/info.py
+++ b/gips/scripts/info.py
@@ -37,6 +37,7 @@ def main():
         cls = import_data_class(args.command)
         cls.print_products()
     except Exception, e:
+        # TODO error-handling-fix: standard script-level handler
         import traceback
         VerboseOut(traceback.format_exc(), 4)
         print 'GIPS Data Repository error: %s' % e

--- a/gips/scripts/info.py
+++ b/gips/scripts/info.py
@@ -31,20 +31,16 @@ def main():
     title = Colors.BOLD + 'GIPS Data Repositories (v%s)' % (gipsversion) + Colors.OFF
 
     # argument parsing
-    try:
-        parser = GIPSParser(description=title)
-        args = parser.parse_args()
 
-        cls = utils.gips_script_setup(args.command, args.stop_on_error)
+    parser = GIPSParser(description=title)
+    args = parser.parse_args()
 
-        print title
-        cls = import_data_class(args.command)
+    cls = utils.gips_script_setup(args.command, args.stop_on_error)
+
+    print title
+
+    with utils.error_handler():
         cls.print_products()
-    except Exception, e:
-        # TODO error-handling-fix: standard script-level handler
-        import traceback
-        VerboseOut(traceback.format_exc(), 4)
-        print 'GIPS Data Repository error: %s' % e
 
     utils.gips_exit() # produce a summary error report then quit with a proper exit status
 

--- a/gips/scripts/inventory.py
+++ b/gips/scripts/inventory.py
@@ -65,7 +65,8 @@ def main():
                        default=False)
     args = parser0.parse_args()
 
-    cls = utils.gips_script_setup(args.command)
+    cls = utils.gips_script_setup(args.command, args.stop_on_error)
+
 
     with utils.error_handler():
         print(title)
@@ -90,6 +91,8 @@ def main():
         for extent in extents:
             inv = DataInventory(cls, extent, TemporalExtent(args.dates, args.days), **vars(args))
             inv.pprint(md=args.md)            
+
+    utils.gips_exit() # produce a summary error report then quit with a proper exit status
 
 if __name__ == "__main__":
     main()

--- a/gips/scripts/mask.py
+++ b/gips/scripts/mask.py
@@ -94,6 +94,7 @@ def main():
             mask_file = None
 
     except Exception, e:
+        # TODO error-handling-fix: standard script-level handler
         import traceback
         VerboseOut(traceback.format_exc(), 4)
         print 'Masking error: %s' % e

--- a/gips/scripts/process.py
+++ b/gips/scripts/process.py
@@ -84,6 +84,7 @@ def main():
                 ofile.writelines(tdl)
 
     except Exception, e:
+        # TODO error-handling-fix: standard script-level handler
         import traceback
         VerboseOut(traceback.format_exc(), 4)
         print 'Data processing error: %s' % e

--- a/gips/scripts/process.py
+++ b/gips/scripts/process.py
@@ -25,6 +25,7 @@ from gips import __version__
 from gips.parsers import GIPSParser
 from gips.core import SpatialExtent, TemporalExtent
 from gips.utils import Colors, VerboseOut, open_vector, import_data_class
+from gips import utils
 from gips.inventory import DataInventory
 from gips.inventory import orm
 
@@ -37,6 +38,8 @@ def main():
     parser0.add_inventory_parser()
     parser0.add_process_parser()
     args = parser0.parse_args()
+
+    cls = utils.gips_script_setup(args.command, args.stop_on_error)
 
     try:
         print title
@@ -88,6 +91,8 @@ def main():
         import traceback
         VerboseOut(traceback.format_exc(), 4)
         print 'Data processing error: %s' % e
+
+    utils.gips_exit() # produce a summary error report then quit with a proper exit status
 
 
 if __name__ == "__main__":

--- a/gips/scripts/process.py
+++ b/gips/scripts/process.py
@@ -40,12 +40,9 @@ def main():
     args = parser0.parse_args()
 
     cls = utils.gips_script_setup(args.command, args.stop_on_error)
+    print title
 
-    try:
-        print title
-        cls = import_data_class(args.command)
-        orm.setup()
-
+    with utils.error_handler():
         extents = SpatialExtent.factory(
             cls, args.site, args.key, args.where, args.tiles, args.pcov,
             args.ptile
@@ -85,12 +82,6 @@ def main():
         if args.batchout:
             with open(args.batchout, 'w') as ofile:
                 ofile.writelines(tdl)
-
-    except Exception, e:
-        # TODO error-handling-fix: standard script-level handler
-        import traceback
-        VerboseOut(traceback.format_exc(), 4)
-        print 'Data processing error: %s' % e
 
     utils.gips_exit() # produce a summary error report then quit with a proper exit status
 

--- a/gips/scripts/project.py
+++ b/gips/scripts/project.py
@@ -82,6 +82,7 @@ def main():
                     2,
                 )
     except Exception as e:
+        # TODO error-handling-fix: standard script-level handler
         import traceback
         VerboseOut(traceback.format_exc(), 4)
         print 'Data Project error: %s' % e

--- a/gips/scripts/project.py
+++ b/gips/scripts/project.py
@@ -26,6 +26,7 @@ from gips import __version__
 from gips.parsers import GIPSParser
 from gips.core import SpatialExtent, TemporalExtent
 from gips.utils import Colors, VerboseOut, import_data_class
+from gips import utils
 from gips.inventory import DataInventory, ProjectInventory
 from gips.inventory import orm
 
@@ -40,6 +41,8 @@ def main():
     parser0.add_project_parser()
     parser0.add_warp_parser()
     args = parser0.parse_args()
+
+    cls = utils.gips_script_setup(args.command, args.stop_on_error)
 
     try:
         print title
@@ -86,6 +89,8 @@ def main():
         import traceback
         VerboseOut(traceback.format_exc(), 4)
         print 'Data Project error: %s' % e
+
+    utils.gips_exit() # produce a summary error report then quit with a proper exit status
 
 
 if __name__ == "__main__":

--- a/gips/scripts/project.py
+++ b/gips/scripts/project.py
@@ -43,11 +43,9 @@ def main():
     args = parser0.parse_args()
 
     cls = utils.gips_script_setup(args.command, args.stop_on_error)
+    print title
 
-    try:
-        print title
-        cls = import_data_class(args.command)
-        orm.setup()
+    with utils.error_handler():
         extents = SpatialExtent.factory(
             cls, args.site, args.key, args.where, args.tiles, args.pcov,
             args.ptile
@@ -84,11 +82,6 @@ def main():
                     .format(str(t_extent), str(t_extent)),
                     2,
                 )
-    except Exception as e:
-        # TODO error-handling-fix: standard script-level handler
-        import traceback
-        VerboseOut(traceback.format_exc(), 4)
-        print 'Data Project error: %s' % e
 
     utils.gips_exit() # produce a summary error report then quit with a proper exit status
 

--- a/gips/scripts/stats.py
+++ b/gips/scripts/stats.py
@@ -34,7 +34,6 @@ def main():
     title = Colors.BOLD + 'GIPS Image Statistics (v%s)' % __version__ + Colors.OFF
 
     parser0 = GIPSParser(datasources=False, description=title)
-    parser0.add_default_parser()
     parser0.add_projdir_parser()
     group = parser0.add_argument_group('masking options')
     args = parser0.parse_args()

--- a/gips/scripts/stats.py
+++ b/gips/scripts/stats.py
@@ -27,6 +27,7 @@ import gippy
 from gips.parsers import GIPSParser
 from gips.inventory import ProjectInventory
 from gips.utils import Colors, VerboseOut, basename
+from gips import utils
 
 __version__ = '0.1.0'
 
@@ -37,6 +38,8 @@ def main():
     parser0.add_projdir_parser()
     group = parser0.add_argument_group('masking options')
     args = parser0.parse_args()
+
+    cls = utils.gips_script_setup(stop_on_error=args.stop_on_error)
 
     # TODO - check that at least 1 of filemask or pmask is supplied
 
@@ -80,6 +83,8 @@ def main():
         import traceback
         VerboseOut(traceback.format_exc(), 4)
         print 'Error: %s' % e
+
+    utils.gips_exit() # produce a summary error report then quit with a proper exit status
 
 
 if __name__ == "__main__":

--- a/gips/scripts/stats.py
+++ b/gips/scripts/stats.py
@@ -77,6 +77,7 @@ def main():
                 files[f].close()
 
     except Exception, e:
+        # TODO error-handling-fix: standard script-level handler
         import traceback
         VerboseOut(traceback.format_exc(), 4)
         print 'Error: %s' % e

--- a/gips/scripts/stats.py
+++ b/gips/scripts/stats.py
@@ -39,11 +39,11 @@ def main():
     group = parser0.add_argument_group('masking options')
     args = parser0.parse_args()
 
-    cls = utils.gips_script_setup(stop_on_error=args.stop_on_error)
+    utils.gips_script_setup(stop_on_error=args.stop_on_error)
 
     # TODO - check that at least 1 of filemask or pmask is supplied
 
-    try:
+    with utils.error_handler():
         print title
         header = ['min', 'max', 'mean', 'sd', 'skew', 'count']
 
@@ -77,12 +77,6 @@ def main():
                     img = None
             for f in files:
                 files[f].close()
-
-    except Exception, e:
-        # TODO error-handling-fix: standard script-level handler
-        import traceback
-        VerboseOut(traceback.format_exc(), 4)
-        print 'Error: %s' % e
 
     utils.gips_exit() # produce a summary error report then quit with a proper exit status
 

--- a/gips/scripts/tiles.py
+++ b/gips/scripts/tiles.py
@@ -70,6 +70,7 @@ def main():
                                               args.res, args.interpolation, args.crop, args.overwrite, args.tree)
 
     except Exception, e:
+        # TODO error-handling-fix: standard script-level handler
         import traceback
         VerboseOut(traceback.format_exc(), 4)
         print 'Warp Tiles error: %s' % e

--- a/gips/scripts/tiles.py
+++ b/gips/scripts/tiles.py
@@ -26,6 +26,7 @@ from gips import __version__
 from gips.parsers import GIPSParser
 from gips.core import SpatialExtent, TemporalExtent
 from gips.utils import Colors, VerboseOut, mkdir, open_vector, import_data_class
+from gips import utils
 from gips.inventory import DataInventory
 from gips.inventory import orm
 
@@ -40,6 +41,8 @@ def main():
     parser0.add_project_parser()
     parser0.add_warp_parser()
     args = parser0.parse_args()
+
+    cls = utils.gips_script_setup(args.command, args.stop_on_error)
 
     try:
         print title
@@ -74,6 +77,8 @@ def main():
         import traceback
         VerboseOut(traceback.format_exc(), 4)
         print 'Warp Tiles error: %s' % e
+
+    utils.gips_exit() # produce a summary error report then quit with a proper exit status
 
 
 if __name__ == "__main__":

--- a/gips/scripts/tiles.py
+++ b/gips/scripts/tiles.py
@@ -43,12 +43,9 @@ def main():
     args = parser0.parse_args()
 
     cls = utils.gips_script_setup(args.command, args.stop_on_error)
+    print title
 
-    try:
-        print title
-        cls = import_data_class(args.command)
-        orm.setup()
-
+    with utils.error_handler():
         # create output directory if needed
         # tld is "{}_tiles_{}_{}".format(DATATYPE, RESOLUTION, SUFFIX)
         if args.notld:
@@ -71,12 +68,6 @@ def main():
                     # warp the tiles & copy into place in the output dir
                     inv[date].tiles[tid].copy(tld, args.products, inv.spatial.site,
                                               args.res, args.interpolation, args.crop, args.overwrite, args.tree)
-
-    except Exception, e:
-        # TODO error-handling-fix: standard script-level handler
-        import traceback
-        VerboseOut(traceback.format_exc(), 4)
-        print 'Warp Tiles error: %s' % e
 
     utils.gips_exit() # produce a summary error report then quit with a proper exit status
 

--- a/gips/test/unit/t_core.py
+++ b/gips/test/unit/t_core.py
@@ -59,6 +59,7 @@ def t_repository_find_dates_normal_case(mocker):
     assert expected == actual
 
 
+@pytest.mark.skip(reason="Letting exception bubble up for now; if that changes un-skip this test.")
 def t_repository_find_dates_error_case(mocker):
     """Confirm Repository.find_dates quits on error."""
     m_list_dates = mocker.patch('gips.data.core.dbinv.list_dates')

--- a/gips/test/unit/t_core.py
+++ b/gips/test/unit/t_core.py
@@ -42,10 +42,9 @@ def t_repository_find_tiles_normal_case(mocker):
 def t_repository_find_tiles_error_case(mocker):
     """Confirm Repository.find_tiles quits on error."""
     m_list_tiles = mocker.patch('gips.data.core.dbinv.list_tiles')
-    m_list_tiles.side_effect = Exception('AAAAAAAAAAH!') # intentionally break list_tiles
+    m_list_tiles.side_effect = RuntimeError('AAAAAAAAAAH!') # intentionally break list_tiles
 
-    # confirm call was still a success via the righ code path
-    with pytest.raises(SystemExit):
+    with pytest.raises(RuntimeError):
         landsatRepository.find_tiles()
 
 

--- a/gips/test/unit/t_utils.py
+++ b/gips/test/unit/t_utils.py
@@ -1,0 +1,154 @@
+"""Unit tests for code found in gips.utils."""
+
+import pytest
+
+from gips import utils
+from gips import inventory
+
+@pytest.yield_fixture
+def restore_error_handler():
+    handler = utils.error_handler
+    yield
+    utils.set_error_handler(handler)
+
+
+def t_set_error_handler(restore_error_handler):
+    """Test setting of the GIPS error handler."""
+    def fake_handler():
+        pass
+    utils.set_error_handler(fake_handler)
+    assert utils.error_handler is fake_handler
+
+
+@pytest.mark.parametrize('verbosity, print_exc_call_cnt', (
+    (utils._traceback_verbosity - 3, 0),
+    (utils._traceback_verbosity + 0, 1),
+    (utils._traceback_verbosity + 3, 1)))
+def t_report_error(mocker, verbosity, print_exc_call_cnt):
+    """Test GIPS' general purpose error reporting."""
+    mocker.patch.object(utils.gippy.Options, 'Verbose').return_value = verbosity
+    m_print_exc = mocker.patch.object(utils.traceback, 'print_exc')
+    m_verbose_out = mocker.patch.object(utils, 'verbose_out')
+
+    utils.report_error(Exception('blarg'), 'error message here')
+
+    assert (m_print_exc.call_count == print_exc_call_cnt and
+            m_verbose_out.call_count == 1)
+
+
+# for t_gips_exit
+e = Exception('aaah!')
+e.msg_prefix = 'oh noze!'
+
+@pytest.mark.parametrize('accum_errors', ([], [e, e, e]))
+def t_gips_exit(mocker, accum_errors):
+    """Test GIPS' exit function."""
+    m_report_error = mocker.patch.object(utils, 'report_error')
+    m_sys_exit = mocker.patch.object(utils.sys, 'exit')
+    m_sys_exit.side_effect = RuntimeError('real one raises SystemExit')
+    mocker.patch.object(utils, '_accumulated_errors', new=accum_errors)
+
+    with pytest.raises(RuntimeError):
+        utils.gips_exit()
+
+    # confirm exit status is 0 if no errors, 1 otherwise:
+    m_sys_exit.assert_called_once_with(0 if len(accum_errors) == 0 else 1)
+    # confirm an error report is generated for each error:
+    assert m_report_error.call_count == len(accum_errors)
+
+
+@pytest.mark.parametrize('driver_string, stop_on_error, setup_orm', (
+    (None,    False, False),
+    (None,    True,  False),
+    ('modis', False, False),
+    (None,    False, True)))
+def t_gips_script_setup(mocker, driver_string, stop_on_error, setup_orm):
+    """Test setup function for GIPS-as-a-CLI-application."""
+    mocker.patch.object(utils, '_stop_on_error', new=False)
+    m_idc = mocker.patch.object(utils, 'import_data_class')
+    m_gips_inv = mocker.Mock()
+    m_gips_inv.orm.setup # to force the child mocks to exist
+    mocker.patch.dict('sys.modules', {'gips.inventory': m_gips_inv})
+
+    rv = utils.gips_script_setup(driver_string, stop_on_error, setup_orm)
+
+    if driver_string is None:
+        m_idc.assert_not_called()
+    else:
+        m_idc.assert_called_once_with(driver_string)
+    assert (utils._stop_on_error == stop_on_error and
+            rv is {True: None, False: m_idc.return_value}[driver_string is None] and
+            m_gips_inv.orm.setup.call_count == {False: 0, True: 1}[setup_orm])
+
+
+def t_lib_error_handler_base_case(mocker):
+    """Test error handler for GIPS' library mode:  non-entry into except."""
+    m_report_error = mocker.patch.object(utils, 'report_error')
+
+    # implicit assertion is that no exception is raised
+    with utils.lib_error_handler():
+        pass # stand-in for non-raising code
+
+    m_report_error.assert_not_called()
+
+
+@pytest.mark.parametrize('continuable, stop_on_error', (
+    (False, False),
+    (False, True),
+    (True,  True)))
+def t_lib_error_handler_reraise(mocker, continuable, stop_on_error):
+    """Test exception-reraising cases of lib_error_handler."""
+    m_report_error = mocker.patch.object(utils, 'report_error')
+
+    mocker.patch.object(utils, '_stop_on_error', new=stop_on_error)
+    with pytest.raises(RuntimeError):
+        with utils.lib_error_handler('PREFIX', continuable):
+            raise RuntimeError("AAAAAH!")
+    m_report_error.assert_not_called()
+
+
+def t_lib_error_handler_continuable_case(mocker):
+    """Test error handler for GIPS' library mode."""
+    m_report_error = mocker.patch.object(utils, 'report_error')
+    mocker.patch.object(utils, '_stop_on_error', new=False)
+
+    rte = RuntimeError("AAAAAH!")
+    with utils.lib_error_handler('PREFIX', True):
+        raise rte
+    m_report_error.assert_called_once_with(rte, 'PREFIX')
+
+
+def t_cli_error_handler_base_case(mocker):
+    """Test error handler for GIPS' CLI mode:  non-entry into except."""
+    m_report_error = mocker.patch.object(utils, 'report_error')
+
+    # implicit assertion is that no exception is raised
+    with utils.cli_error_handler():
+        pass # stand-in for non-raising code
+
+    m_report_error.assert_not_called()
+
+@pytest.mark.parametrize('continuable, stop_on_error', (
+    (False, False),
+    (False, True),
+    (True,  True)))
+def t_cli_error_handler_reraise(mocker, continuable, stop_on_error):
+    """Test exception-reraising cases of cli_error_handler."""
+    m_report_error = mocker.patch.object(utils, 'report_error')
+    m_gips_exit = mocker.patch.object(utils, 'gips_exit')
+
+    mocker.patch.object(utils, '_stop_on_error', new=stop_on_error)
+    with utils.cli_error_handler('PREFIX', continuable):
+        raise RuntimeError("AAAAAH!")
+    assert 0 == m_report_error.call_count and 1 == m_gips_exit.call_count
+
+
+def t_cli_error_handler_continuable_case(mocker):
+    """Test error handler for GIPS' CLI mode."""
+    m_report_error = mocker.patch.object(utils, 'report_error')
+    mocker.patch.object(utils, '_stop_on_error', new=False)
+
+    rte = RuntimeError("AAAAAH!")
+    with utils.cli_error_handler('PREFIX', True):
+        raise rte
+    m_report_error.assert_called_once_with(rte, 'PREFIX')

--- a/gips/tiles.py
+++ b/gips/tiles.py
@@ -98,6 +98,8 @@ class Tiles(object):
                     else:
                         mosaic(images, fout, self.spatial.site)
                 except Exception, e:
+                    # TODO error-handling-fix: let the exception propagate AND have the callers handle it instead
+                    # TODO error-handling-fix: note call is in gips/inventory/__init__.py: self.data[d].mosaic(dout, **kwargs)
                     VerboseOut(traceback.format_exc(), 4)
                     VerboseOut("Error mosaicking %s: %s" % (fout, e))
         t = datetime.now() - start

--- a/gips/user_settings_template.py
+++ b/gips/user_settings_template.py
@@ -23,12 +23,15 @@
 
 # GIPS user settings file
 
-# this will try to read in an environment (e.g., system-level or virtual)
+# this block will try to read in an environment (e.g., system-level or virtual)
 # settings file so that individual settings can be changed
-import gips.settings
-execfile(gips.settings.__file__.rstrip('c'))
+try:
+    import gips.settings
+    execfile(gips.settings.__file__.rstrip('c'))
+except:
+    # TODO error-handling-fix: with handler
+    raise Exception('There are no environment-level GIPS settings!')
 
-# place user settings here or below:
 
 # change email used for FTP
 #EMAIL = ''

--- a/gips/user_settings_template.py
+++ b/gips/user_settings_template.py
@@ -23,15 +23,12 @@
 
 # GIPS user settings file
 
-# this block will try to read in an environment (e.g., system-level or virtual)
+# this will try to read in an environment (e.g., system-level or virtual)
 # settings file so that individual settings can be changed
-try:
-    import gips.settings
-    execfile(gips.settings.__file__.rstrip('c'))
-except:
-    # TODO error-handling-fix: with handler
-    raise Exception('There are no environment-level GIPS settings!')
+import gips.settings
+execfile(gips.settings.__file__.rstrip('c'))
 
+# place user settings here or below:
 
 # change email used for FTP
 #EMAIL = ''

--- a/gips/user_settings_template.py
+++ b/gips/user_settings_template.py
@@ -29,6 +29,7 @@ try:
     import gips.settings
     execfile(gips.settings.__file__.rstrip('c'))
 except:
+    # TODO error-handling-fix: with handler
     raise Exception('There are no environment-level GIPS settings!')
 
 

--- a/gips/utils.py
+++ b/gips/utils.py
@@ -395,9 +395,12 @@ def set_error_handler(handler):
     error_handler = handler
 
 
-def report_error(error, msg_prefix):
-    """Print an error report on stderr, respecting verbosity."""
-    if gippy.Options.Verbose() >= _traceback_verbosity:
+def report_error(error, msg_prefix, show_tb=True):
+    """Print an error report on stderr, possibly including a traceback.
+
+    Caller can suppress the traceback with show_tb.  The user can suppress
+    it via the GIPS global verbosity setting."""
+    if show_tb and gippy.Options.Verbose() >= _traceback_verbosity:
         verbose_out(msg_prefix + ':', 1, stream=sys.stderr)
         traceback.print_exc()
     else:
@@ -424,7 +427,7 @@ def gips_exit():
     if len(_accumulated_errors) == 0:
         sys.exit(0)
     verbose_out("Fatal: {} error(s) occurred:".format(len(_accumulated_errors)), 1, sys.stderr)
-    [report_error(error, error.msg_prefix) for error in _accumulated_errors]
+    [report_error(error, error.msg_prefix, show_tb=False) for error in _accumulated_errors]
     sys.exit(1)
 
 

--- a/gips/utils.py
+++ b/gips/utils.py
@@ -100,6 +100,15 @@ def List2File(lst, filename):
 
 
 def RemoveFiles(filenames, extensions=['']):
+    """Remove the given filenames with os.remove.
+
+    Pass in a list of extensions to treat each filename as a prefix and
+    extensions as suffixes, and remove all possible combinations.
+    """
+    # TODO error-handling-fix: this whole function looks strange:
+    #   when extensions is [''], same filename is tried twice
+    #   don't use a mutable type as a default argument
+    #   why give up on all files once one extension fails?
     for f in filenames:
         for ext in ([''] + extensions):
             try:
@@ -144,6 +153,7 @@ def link(src, dst, hard=False):
 
 def settings():
     """ Retrieve GIPS settings - first from user, then from system """
+    # TODO error-handling-fix: reconsider this whole function
     import imp
     try:
         # import user settings first
@@ -162,6 +172,8 @@ def settings():
 
 def create_environment_settings(repos_path, email=''):
     """ Create settings file and data directory """
+    # TODO error-handling-fix: this is called only once, in gips/scripts/config.py
+    # TODO error-handling-fix: consider refactoring it away
     from gips.settings_template import __file__ as src
     cfgpath = os.path.dirname(__file__)
     cfgfile = os.path.join(cfgpath, 'settings.py')
@@ -176,7 +188,8 @@ def create_environment_settings(repos_path, email=''):
         return cfgfile
     except OSError:
         # no permissions, so no environment level config installed
-        #print traceback.format_exc()
+        #print traceback.format_exck()
+        # TODO error-handling-fix: continuable handler
         return None
 
 
@@ -203,6 +216,7 @@ def create_repos():
     try:
         repos = settings().REPOS
     except:
+        # TODO error-handling-fix: with handler
         print(traceback.format_exc())
         raise Exception('Problem reading repository...check settings files')
     for key in repos.keys():
@@ -215,6 +229,8 @@ def create_repos():
 
 def data_sources():
     """ Get enabled data sources (and verify) from settings """
+    # TODO error-handling-fix: called once by gips/parsers.py, refactor to over there?
+    # TODO error-handling-fix: also there's something odd about the for-if-try, sort it out
     sources = {}
     repos = settings().REPOS
     found = False
@@ -244,6 +260,7 @@ def import_data_module(clsname):
         mod = imp.load_module(clsname, *fmtup)
         return mod
     except:
+        # TODO error-handling-fix: no try-except needed; GIPS can't proceed if this fails
         print(traceback.format_exc())
 
 
@@ -286,6 +303,7 @@ def open_vector(fname, key="", where=''):
             vector.SetPrimaryKey(key)
 
         except Exception as e:
+            # TODO error-handling-fix: can't open a vector = done working, so let it raise
             VerboseOut(traceback.format_exc(), 4)
     if where != '':
         # return array of features

--- a/gips/utils.py
+++ b/gips/utils.py
@@ -458,14 +458,14 @@ def cli_error_handler(msg_prefix='Error', continuable=False):
             gips_exit()
 
 
-def gips_script_setup(driver_string=None, stop_on_error=False, orm=True):
+def gips_script_setup(driver_string=None, stop_on_error=False, setup_orm=True):
     """Run this at the beginning of a GIPS CLI program to do setup."""
     global _stop_on_error
     _stop_on_error = stop_on_error
     set_error_handler(cli_error_handler)
     from gips.inventory import orm # avoids a circular import
     with error_handler():
-        if orm:
+        if setup_orm:
             orm.setup()
         if driver_string is not None:
             return import_data_class(driver_string)

--- a/gips/utils.py
+++ b/gips/utils.py
@@ -380,7 +380,7 @@ def mosaic(images, outfile, vector):
 _traceback_verbosity = 4    # only print a traceback if the user selects this verbosity or higher
 _accumulated_errors = []    # used for tracking success/failure & doing final error reporting when
                             # GIPS is running as a command-line application
-_stop_on_error = False      # TODO set by cmd-line option
+_stop_on_error = False      # should GIPS try to recover from errors?  Set by gips_script_setup
 
 
 def set_error_handler(handler):
@@ -440,12 +440,14 @@ def cli_error_handler(continuable=False, msg_prefix='Error'):
             gips_exit()
 
 
-def gips_script_setup(driver_string, data_class=True, orm=True):
+def gips_script_setup(driver_string=None, stop_on_error=False, orm=True):
     """Run this at the beginning of a GIPS CLI program to do setup."""
-    from gips.inventory import orm # avoids a circular import
+    global _stop_on_error
+    _stop_on_error = stop_on_error
     set_error_handler(cli_error_handler)
+    from gips.inventory import orm # avoids a circular import
     with error_handler():
         if orm:
             orm.setup()
-        if data_class:
+        if driver_string is not None:
             return import_data_class(driver_string)

--- a/gips/utils.py
+++ b/gips/utils.py
@@ -417,7 +417,7 @@ def report_error(error, msg_prefix):
 
 
 @contextmanager
-def lib_error_handler(continuable=False, msg_prefix='Error'):
+def lib_error_handler(msg_prefix='Error', continuable=False):
     """Handle errors appropriately for GIPS running as a library."""
     try:
         yield
@@ -441,7 +441,7 @@ def gips_exit():
 
 
 @contextmanager
-def cli_error_handler(continuable=False, msg_prefix='Error'):
+def cli_error_handler(msg_prefix='Error', continuable=False):
     """Context manager for uniform error handling for command-line users.
 
     Exceptions are caught and reported to stderr; _gips_exit() is called

--- a/gips/utils.py
+++ b/gips/utils.py
@@ -150,26 +150,24 @@ def link(src, dst, hard=False):
 # Settings functions
 ##############################################################################
 
-loaded_settings = None
 
 def settings():
     """ Retrieve GIPS settings - first from user, then from system """
-    global loaded_settings
-    if loaded_settings is not None:
-        return loaded_settings
-
+    # TODO error-handling-fix: reconsider this whole function
     import imp
-    user_settings_path = '~/.gips/settings.py'
-    msg_prefix = "Falling back to global settings; couldn't load {}".format(user_settings_path)
-    with error_handler(msg_prefix, continuable=True):
-        # attempt to import user settings first, falling back to global settings otherwise
-        loaded_settings = imp.load_source('settings', os.path.expanduser(user_settings_path))
-        return loaded_settings
-
-    with error_handler("Couldn't load global settings"):
-        import gips.settings
-        loaded_settings = gips.settings
-        return loaded_settings
+    try:
+        # import user settings first
+        src = imp.load_source(
+            'settings',
+            os.path.expanduser('~/.gips/settings.py')
+        )
+        return src
+    except (ImportError, IOError) as e:
+        try:
+            import gips.settings
+            return gips.settings
+        except ImportError:
+            raise ImportError('No settings found...did you run gips_config?')
 
 
 def create_environment_settings(repos_path, email=''):


### PR DESCRIPTION
Two-mode error-handling for GIPS; fix for issue #8.  One mode lets GIPS behave well as a library; mostly on error it reports to stderr then re-raises properly.  The other mode lets GIPS play nice as part of a CLI application, in that it doesn't report tracebacks unless verbosity is high.  Both modes support optional 'continuable' errors, which lets GIPS keep working after some errors, if the user permits.  The new error handler looks like this in situ:  `with utils.error_handler('Bad date specification'):`

Walking the code one will see this stuff:
* New error handling implemented in `gips.utils`, along with backing code for setup & config; unit tests also
* GIPSParser changed to have consistent and (now) necessary command-line options for all gips programs.
* Critical and problematic try-except blocks in gips core code, as well as modis and landsat, has been changed to use the utility error handler.
* The most important gips commands now use the utility error handling at the top level, and incorporate setup and teardown code for the purpose.
* All remaining try-excepts in GIPS are now labelled for future revision to use the error handler, with a comment like this:  `# TODO error-handling-fix: blah blah blah`.
* drop custom error-handling in `dbinv` and make it use the utility handler.
* refactoring in various places as needed to accomodate these changes

tolson OUT.

:raised_hand_with_fingers_splayed: 
:arrow_down:
:microphone: 