### PR TITLE
proto: datahandler scaffolding & working fetch()

### DIFF
--- a/gips/data/core.py
+++ b/gips/data/core.py
@@ -472,6 +472,7 @@ class Asset(object):
                         with utils.error_handler('Unable to make data directory ' + tpath):
                             os.makedirs(tpath)
                     with utils.error_handler('Problem adding {} to archive'.format(filename)):
+                        # needs full path
                         os.link(os.path.abspath(filename), newfilename)
                         asset.archived_filename = newfilename
                         VerboseOut(bname + ' -> ' + newfilename, 2)

--- a/gips/data/modis/modis.py
+++ b/gips/data/modis/modis.py
@@ -205,6 +205,7 @@ class modisAsset(Asset):
         with utils.error_handler(err_msg):
             listing = urllib.urlopen(mainurl).readlines()
 
+        retrieved_filenames = []
         success = False
         for item in listing:
             # screen-scrape the content of the page and extract the full name of the needed file
@@ -242,10 +243,13 @@ class modisAsset(Asset):
                             for chunk in response.iter_content():
                                 fd.write(chunk)
                     utils.verbose_out('Retrieved %s' % name, 2)
+                    retrieved_filenames.append(outpath)
                     success = True
 
         if not success:
             VerboseOut('Unable to find remote match for %s at %s' % (pattern, mainurl), 4)
+        return retrieved_filenames
+
 
     def updated(self, newasset):
         '''

--- a/gips/datahandler/__init__.py
+++ b/gips/datahandler/__init__.py
@@ -1,0 +1,1 @@
+from .api import *

--- a/gips/datahandler/api.py
+++ b/gips/datahandler/api.py
@@ -1,0 +1,26 @@
+"""GIPS scheduler API, for scheduling work and checking status of same."""
+
+from gips import utils
+
+from gips.datahandler import torque
+
+
+# entry point for Tom's bit for the demo; Tom doesn't go "further up" at the
+# moment.
+def schedule(assets=None, products=None, export_spec=None, aggregation=None, config=None):
+    """Pass a work spec in to the scheduler, and the work will be done.
+
+    Schedules the work by defining and starting a series of jobs managed by a
+    supporting task queueing or batching system.
+
+    assets:         list of the form (driver, asset_type, tile, date)
+    products:       list of the form (driver, product_type, tile, date)
+    export_spec:    TBD gips_project
+    aggregation:    TBD zonal summary
+    config:         TBD scheduling params such as how the work should be
+                    divided; leave as None for a sensible default, which is 
+                    in turn TBD.
+
+    """
+    # TODO does this function set 'requested' on workers?
+

--- a/gips/datahandler/torque.py
+++ b/gips/datahandler/torque.py
@@ -1,0 +1,74 @@
+"""Torque-based backend for the GIPS work scheduler."""
+
+# originally copied from:
+# https://raw.githubusercontent.com/jdherman/hpc-submission-scripts/master/submit-pbs-loop.py
+
+from subprocess import Popen, PIPE
+
+from gips import utils
+
+pbs_directives = [
+    # for meaning of directives see
+    #   http://docs.adaptivecomputing.com/torque/4-0-2/Content/topics/commands/qsub.htm
+    '-N bsbreeder_job',
+    '-A bsbreeder_test_contract:bsbreeder_test_task',
+    '-k oe',
+    '-j oe',
+    '-V',
+    '-l walltime=1:00:00',
+    '-l nodes=1:ppn=1',
+]
+
+test_job_string = """
+# from gips.datahandler import worker
+
+iterations = 20
+
+def backslash_breeder(n, v=''):
+    if n <= 1:
+        return repr(v)
+    else:
+        return repr(backslash_breeder(n - 1, v))
+
+print len(backslash_breeder(iterations))
+"""
+
+def submit(operation, args, batch_size=None):
+    """Submit jobs to the configured Torque system.
+
+    operation:  Defines which function will be performed, and must be one of
+        'fetch', 'process', 'export', or 'postprocess'.
+    args:  An iterable of tuples; each tuple represents the arguments to
+        one call to the chosen function.
+    batch_size:  The work is divided among torque jobs; each job receives
+        batch_size function calls to perform in a loop.  Leave None for one job
+        that works the whole batch.
+    """
+    if operation not in ('fetch', 'process', 'export', 'postprocess'):
+        err_msg = ("'{}' is an invalid operation (valid operations are "
+                   "'fetch', 'process', 'export', and 'postprocess')".format(operation))
+        raise ValueError(err_msg)
+
+    # TODO type & arity checking of args
+
+    # Open a pipe to the qsub command.
+    proc = Popen('qsub', shell=True, stdin=PIPE, stdout=PIPE, stderr=PIPE, close_fds=True)
+
+    remote_python = utils.settings().REMOTE_PYTHON
+    job_string = '\n'.join(['#!' + remote_python] + ['#PBS ' + d for d in pbs_directives])
+
+    # TODO wire in operation/args/batch_size here
+
+    job_string += test_job_string
+
+    # Send job_string to qsub
+    proc.stdin.write(job_string)
+    out, err = proc.communicate()
+
+    # Print your job and the system response to the screen as it's submitted
+    print "SCRIPT TEXT (job_string):"
+    print job_string
+    print "OUT:"
+    print out
+    print "ERR:"
+    print err

--- a/gips/datahandler/worker.py
+++ b/gips/datahandler/worker.py
@@ -1,0 +1,64 @@
+"""Worker functions for GIPS scheduled tasks.
+
+Called inside worker processes; first implementation is expected to be torque
+jobs.
+"""
+
+from django.db import transaction, IntegrityError
+
+from gips import utils
+from gips.inventory import dbinv
+
+
+def fetch(driver, asset_type, tile, date):
+    """Fetch the asset file specified."""
+    # Notify everyone that this process is doing the fetch.
+    with transaction.atomic():
+        # TODO confirm transaction.atomic prevents DB writes while it's active
+        asset = dbinv.models.Asset.objects.get(
+                driver=driver, asset=asset_type, tile=tile, date=date)
+        if asset.status.status in ('in-progress', 'complete'):
+            # TODO log/msg about giving up here
+            return asset
+        asset.status = dbinv.models.Status.objects.get(status='in-progress')
+        asset.save()
+
+    # locate the correct fetch function & execute it, then archive the file and update the DB
+    DataClass  = utils.import_data_class(driver)
+    AssetClass = DataClass.Asset
+    filenames  = AssetClass.fetch(asset_type, tile, date)
+    a_obj = AssetClass._archivefile(filenames[0])[0] # for now neglect the 'update' case
+
+    # update DB now that the work is done; no need for an atomic transaction
+    # because the only critical action is Model.save(), which is already atomic
+    asset.refresh_from_db()
+    if asset.status.status is not 'in-progress':
+        # sanity check; have to keep going but do whine about it
+        err_msg = "Expected Asset status to be 'in-progress' but got '{}'"
+        utils.verbose_out(err_msg.format(asset.status.status), 1)
+    asset.sensor = a_obj.sensor
+    asset.name   = a_obj.archived_filename
+    asset.status = dbinv.models.Status.objects.get(status='complete')
+    asset.save()
+
+    if len(filenames) > 1:
+        err_msg = 'Expected to fetch one asset but fetched {} instead'.format(len(filenames))
+        raise ValueError(err_msg, filenames)
+    return asset
+
+
+##### TODO unimplemented here down - needs doing for the demo #####
+
+def process(driver, product_type, tile, date):
+    """Produce the specified product file."""
+    pass
+
+
+def export(*args, **kwargs):
+    """Entirely TBD but does the same things as gips_project."""
+    pass
+
+
+def post_process(*args, **kwargs):
+    """Entirely TBD but will support what used to be called zonalsummary ."""
+    pass

--- a/gips/inventory/dbinv/models.py
+++ b/gips/inventory/dbinv/models.py
@@ -6,6 +6,8 @@ from django.db import models
 class Status(models.Model):
     """Status of asset or product"""
 
+    # present valid status values (taken from fixtures/dbinv_status.json):
+    # requested, in-progress, complete, failed
     status = models.TextField()
 
 

--- a/gips/test/int/t_datahandler.py
+++ b/gips/test/int/t_datahandler.py
@@ -1,0 +1,52 @@
+
+import os
+import datetime
+
+import pytest
+import envoy
+
+from gips.inventory import dbinv, orm
+from gips.test.sys import util
+
+@pytest.fixture
+def status_table(db, request):
+    for s in 'requested', 'in-progress', 'complete', 'failed':
+        dbinv.models.Status(status=s).save()
+
+
+@pytest.mark.django_db()
+def t_fetch(status_table):
+    """Simple test for worker.fetch.  Warning:  Operates destructively."""
+    from gips.datahandler.worker import fetch
+    import gippy
+
+    # config
+    gippy.Options.SetVerbose(4) # substantial verbosity for testing purposes
+
+    os.environ['GIPS_ORM'] = 'true'
+    key_kwargs = dict(driver='modis', 
+                      asset ='MCD43A2', 
+                      tile  ='h12v04',
+                      date  =datetime.date(2012, 12, 1))
+    fetch_args = tuple(key_kwargs[k] for k in ('driver', 'asset', 'tile', 'date'))
+    api_kwargs = dict(sensor='dontcare', 
+                      name  ='unspecified',
+                      status='requested',
+                      **key_kwargs)
+    expected = os.path.join(
+            util.DATA_REPO_ROOT,
+            # taken from the modis fetch test; hash isn't used but is:  531008224
+            'modis/tiles/h12v04/2012336/MCD43A2.A2012336.h12v04.006.2016112010833.hdf')
+
+    # setup
+    orm.setup()
+    if os.path.exists(expected): # remove the asset if it's present
+        os.remove(expected)
+    dbinv.update_or_add_asset(**api_kwargs) # set the asset to 'requested' status
+
+    # test
+    returned_asset = fetch(*fetch_args)
+    queried_asset = dbinv.models.Asset.objects.get(**key_kwargs)
+    assert (expected == returned_asset.name == queried_asset.name
+            and 'complete' == returned_asset.status.status == queried_asset.status.status
+            and os.path.isfile(expected))

--- a/gips/utils.py
+++ b/gips/utils.py
@@ -416,6 +416,7 @@ def lib_error_handler(msg_prefix='Error', continuable=False):
         if continuable and not _stop_on_error:
             report_error(e, msg_prefix)
         else:
+            report_error(e, msg_prefix, show_tb=False)
             raise
 
 


### PR DESCRIPTION
This can either merge into the batch-scheduler branch or can sit here to grow more commits as I work on the prototype.  Now that I have something to schedule (fetch), I'm stepping up one level to the job submitter.

big items:
* scaffolding & stubs for the scheduler, mostly under datahandler/
* single-asset fetching function, currently works with modis:
        gips.datahandler.worker.fetch
* draft of pure python torque work submitter

small items mostly to support big stuff:
* adapt dbinv.api to use asset status more conveniently
* change modisAsset.fetch to return list of retrieved filenames
* hack lib_herror_handler so it doesn't neglect the error prefix string
* integration test:  calls fetch() programmatically but actually fetches an
  asset from modis servers