### PR TITLE
quick PR to integrate export into worker functions

### DIFF
--- a/gips/datahandler/torque.py
+++ b/gips/datahandler/torque.py
@@ -34,12 +34,7 @@ orm.setup()
 """
 
 def generate_script(operation, args_batch):
-    if operation not in ('query', 'fetch', 'process'):
-        raise NotImplementedError('only fetch is supported')
-    if operation not in ('query', 'fetch', 'process', 'export', 'postprocess'):
-        err_msg = ("'{}' is an invalid operation (valid operations are "
-                   "'fetch', 'process', 'export', and 'postprocess')".format(operation))
-        raise ValueError(err_msg)
+    """Produce torque script from given worker function and arguments."""
     lines = []
     lines.append('#!' + utils.settings().REMOTE_PYTHON) # shebang
     lines += ['#PBS ' + d for d in pbs_directives]      # #PBS directives
@@ -48,7 +43,6 @@ def generate_script(operation, args_batch):
 
     # star of the show, the actual fetch
     for args in args_batch:
-        #lines.append("worker.{}({}, {}, {}, {})".format(operation, *[repr(i) for i in args]))
         lines.append("worker.{}{}".format(operation, tuple(args)))
 
     return '\n'.join(lines) # stitch into single string & return
@@ -65,9 +59,7 @@ def submit(operation, args_ioi, batch_size=None):
         batch_size function calls to perform in a loop.  Leave None for one job
         that works the whole batch.
     """
-    if operation not in ('query', 'fetch', 'process'):
-        raise NotImplementedError('only fetch is supported')
-    if operation not in ('query', 'fetch', 'process', 'export', 'postprocess'):
+    if operation not in ('query', 'fetch', 'process', 'export', 'export_and_aggregate'):
         err_msg = ("'{}' is an invalid operation (valid operations are "
                    "'fetch', 'process', 'export', and 'postprocess')".format(operation))
         raise ValueError(err_msg)

--- a/gips/datahandler/worker.py
+++ b/gips/datahandler/worker.py
@@ -155,7 +155,8 @@ def _aggregate(*args, **kwargs):
     raise NotImplemented('Dunno what to do here')
 
 
-def aggregate(driver, *args, **kwargs):
+def export_and_aggregate(kwargs):
     """Entirely TBD but does the same things as gips_project + zonal summary."""
-    # TODO export step
-    # TODO spatial aggregator
+    _export(**kwargs)
+    agg_kwargs = {'outdir': kwargs['outdir']}
+    _aggregate(**kwargs)


### PR DESCRIPTION
Note that I tested it with a quick and dirty script and observed the
torque job build the product files in the output dir.  Also removed some
increasingly pointless gatekeeping per advice from a colleague.