### PR TITLE
fix broken argument parsing for mask & archive

### DIFF
--- a/gips/scripts/archive.py
+++ b/gips/scripts/archive.py
@@ -31,8 +31,7 @@ def main():
     title = Colors.BOLD + 'GIPS Data Archive Utility (v%s)' % gipsversion + Colors.OFF
 
     # argument parsing
-    parser0 = GIPSParser(description=title)
-    parser = parser0.add_default_parser()
+    parser = GIPSParser(description=title)
     group = parser.add_argument_group('archive options')
     group.add_argument('--keep', help='Keep files after adding to archive', default=False, action='store_true')
     group.add_argument('--recursive', help='Iterate through subdirectories', default=False, action='store_true')
@@ -42,7 +41,7 @@ def main():
         default=False,
         action='store_true'
     )
-    args = parser0.parse_args()
+    args = parser.parse_args()
 
     try:
         print title

--- a/gips/scripts/mask.py
+++ b/gips/scripts/mask.py
@@ -33,10 +33,9 @@ __version__ = '0.1.0'
 def main():
     title = Colors.BOLD + 'GIPS Project Masking (v%s)' % __version__ + Colors.OFF
 
-    parser0 = GIPSParser(datasources=False, description=title)
-    parser0.add_default_parser()
-    parser0.add_projdir_parser()
-    group = parser0.add_argument_group('masking options')
+    parser = GIPSParser(datasources=False, description=title)
+    parser.add_projdir_parser()
+    group = parser.add_argument_group('masking options')
     group.add_argument('--filemask', help='Mask all files with this static mask', default=None)
     group.add_argument('--pmask', help='Mask files with this corresponding product', nargs='*', default=[])
     h = 'Write mask to original image instead of creating new image'
@@ -45,9 +44,7 @@ def main():
     group.add_argument('--overwrite', help=h, default=False, action='store_true')
     h = 'Suffix to apply to masked file (not compatible with --original)'
     group.add_argument('--suffix', help=h, default='-masked')
-    #parser0.add_argument('-i', '--invert', help='Invert mask (0->1, 1->0)', default=False, action='store_true')
-    #parser0.add_argument('--value', help='Mask == val', default=1)
-    args = parser0.parse_args()
+    args = parser.parse_args()
 
     # TODO - check that at least 1 of filemask or pmask is supplied
 


### PR DESCRIPTION
For some reason these commands were never caught up to the change to the way the default parser was added.