### PR TITLE
_aggregate function changes

### DIFF
--- a/gips/datahandler/worker.py
+++ b/gips/datahandler/worker.py
@@ -12,6 +12,7 @@ from gips.datahandler import api
 from gips.core import SpatialExtent, TemporalExtent
 from gips.inventory import DataInventory, ProjectInventory
 from gips.inventory import dbinv, orm
+from gips.scripts.spatial_wrapper import aggregate
 
 
 def query (job):
@@ -158,7 +159,7 @@ def _export(**kwargs):
 
 
 def _aggregate(job_id, outdir):
-    raise NotImplemented('Dunno what to do here')
+    aggregate(outdir, job_id)
 
 
 def export_and_aggregate(job_id, export_kwargs):

--- a/gips/scripts/spatial_wrapper.py
+++ b/gips/scripts/spatial_wrapper.py
@@ -56,6 +56,25 @@ def get_job(job):
     return job
 
 
+def aggregate(projdir, job_id, nprocs=1):
+    job = get_job(job_id)
+    dv = job.variable
+
+    proj_name = os.path.basename(os.path.dirname(projdir))
+
+    args = {
+        'bands': [dv.band_number],
+        'products': [dv.product],
+        'projdir': projdir,
+        'processes': nprocs,
+
+    }
+
+    results = SpatialAggregator.aggregate(**args)
+    for r in results:
+        make_result(r, dv, job_id)
+
+
 def main():
     path = os.path.dirname(os.path.abspath(__file__))
     desc = '''A wrapper for the Spatial Aggregator tool which creates Result
@@ -85,24 +104,11 @@ def main():
 
     init_args = parser.parse_args()
     projdir = init_args.projdir
-    job = get_job(init_args.job)
-    g_id = job.pk
-    g_dv = job.variable
+    job_id = init_args.job
     nprocs = init_args.num_procs
 
-    proj_name = os.path.basename(os.path.dirname(projdir))
+    aggregate(projdir, job_id, nprocs)
 
-    args = {
-        'bands': [g_dv.band_number],
-        'products': [g_dv.product],
-        'projdir': projdir,
-        'processes': nprocs,
-
-    }
-
-    results = SpatialAggregator.aggregate(**args)
-    for r in results:
-        make_result(r, g_dv, g_id)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR hooks up the _aggregate function for export_and_aggregate. Currently it just calls one of the methods of spatial_wrapper. Spatial_wrapper was written to be a command line application but isn't being used that way, so changes should probably be made here.

_aggregate requires a Job and an export/project directory as inputs.

Job:
`{u'id': 1,
 'site': u'banana',
 'spatial': u"{'site': ['h12v04']}",
 'status': u'requested',
 'temporal': u"{'dates': '2012-336,2012-338'}",
 'variable': 11}`

Variable 11 points to `modis_indices_evi` in my DB.

To get an export directory:
`﻿⁠⁠⁠⁠py.test -s -vv -k 't_export_helper'`

_aggregate should produce 3 Result objects.

Tests are currently being written.