### PR TITLE
fix broken unit tests for remove_files

### DIFF
--- a/gips/test/unit/t_utils.py
+++ b/gips/test/unit/t_utils.py
@@ -13,8 +13,11 @@ def t_remove_files(mocker):
     filenames = ['a.hdf', 'b.hdf']
     extensions = ['.index', '.aux.xml']
     removals = ('a.hdf', 'a.hdf.index', 'a.hdf.aux.xml', 'b.hdf', 'b.hdf.index', 'b.hdf.aux.xml')
+    m_isfile = mocker.patch.object(utils.os.path, 'isfile')
+    m_isfile.return_value = True
     m_os_remove = mocker.patch.object(utils.os, 'remove')
     utils.remove_files(filenames, extensions)
+    [m_isfile.assert_any_call(r) for r in removals]
     [m_os_remove.assert_any_call(r) for r in removals]
     assert m_os_remove.call_count == 6
 
@@ -23,9 +26,12 @@ def t_remove_files_no_ext(mocker):
     """remove_files should work correctly when `extensions` is defaulted."""
     filenames = ['a.hdf', 'b.hdf']
     removals = ('a.hdf', 'b.hdf')
+    m_isfile = mocker.patch.object(utils.os.path, 'isfile')
+    m_isfile.return_value = True
     m_os_remove = mocker.patch.object(utils.os, 'remove')
     utils.remove_files(filenames)
     [m_os_remove.assert_any_call(r) for r in removals]
+    [m_isfile.assert_any_call(r) for r in removals]
     assert m_os_remove.call_count == 2
 
 

--- a/gips/utils.py
+++ b/gips/utils.py
@@ -103,9 +103,9 @@ def List2File(lst, filename):
 def remove_files(filenames, extensions=()):
     """Remove the given files and all permutations with the given extensions.
 
-    So RemoveFiles(['a.hdf', 'b.hdf'], ['.index', '.aux.xml']) attempts to
+    So remove_files(['a.hdf', 'b.hdf'], ['.index', '.aux.xml']) attempts to
     these files:  a.hdf, b.hdf, a.hdf.index, a.hdf.aux.xml, b.hdf,
-    b.hdf.index, and b.hdf.aux.xml.
+    b.hdf.index, and b.hdf.aux.xml.  Doesn't raise an error if any file doesn't exist.
     """
     for f in (list(filenames) + [f + e for f in filenames for e in extensions]):
         with error_handler(continuable=True, msg_prefix="Error removing '{}'".format(f)):


### PR DESCRIPTION
Apparently I'm batting 1.000 this week: I missed two tests for remove_files that broke with the recent merge; this fixes them.

PS - Accidently made this PR against gipit/gips just now; closed it and opened this one.