### PR TITLE
relax six requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-six==1.9.0
+six>=1.9.0
 requests

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         'landsat-util==0.8.0ircwaves0',
     ],
     dependency_links=[
-        'http://github.com/ircwaves/landsat-util/tarball/develop#egg=landsat-util-0.8.0ircwaves0'
+        'http://github.com/ircwaves/landsat-util/tarball/landsat_util#egg=landsat-util-0.8.0ircwaves0'
     ],
     entry_points={'console_scripts': console_scripts},
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -61,10 +61,10 @@ setup(
         'python-dateutil',
         'pydap',
         'pysolar==0.6',
-        'landsat-util==0.8.0ircwaves',
+        'landsat-util==0.8.0ircwaves0',
     ],
     dependency_links=[
-        'http://github.com/ircwaves/landsat-util/tarball/develop#egg=landsat-util-0.8.0ircwaves'
+        'http://github.com/ircwaves/landsat-util/tarball/develop#egg=landsat-util-0.8.0ircwaves0'
     ],
     entry_points={'console_scripts': console_scripts},
     zip_safe=False,


### PR DESCRIPTION
`matplotlib==2.0` requires `six==1.10`, so these requirements are tweaked in gips (and my landsat-util fork) to be `six>=1.9`.  This makes it such that there is not a version conflict for gips install.  I have tested that gips now installs happily in a fresh container.
