### PR TITLE
Expectations format option for system tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -40,13 +40,17 @@ def pytest_addoption(parser):
 
     parser.addoption("--slow", action="store_true", help="Do not skip @slow tests.")
 
-    help_str = ("Do not skip @src_altering tests, which are tests that may "
+    help_str = ("Do not skip @src_altering system tests, which are tests that may "
                 "alter or remove source data in the repo.")
     parser.addoption("--src-altering", action="store_true", help=help_str)
 
     help_str = ("Do not skip @system tests, which are tests that may "
                 "change elements of the environment as they work.")
     parser.addoption("--sys", action="store_true", help=help_str)
+
+    help_str = ("Whenever a subprocess' output streams are captured via GipsTestFileEnv,"
+                " print them out in a format suitable for cutpasting into an expectations file.")
+    parser.addoption("--expectation-format", action="store_true", help=help_str)
 
 
 def pytest_configure(config):

--- a/gips/test/README.md
+++ b/gips/test/README.md
@@ -232,8 +232,9 @@ which is convenient for making assertions in these system tests.
 
 The known-good values stored in `expected/` are usually captured from initial
 test runs.  For convenience, newly developed tests may be run with
-`py.test -s --log-level debug`; parts of the output can be cutpasted into an
-`expected/` file to establish these needed known-good values.
+`py.test -s --log-level debug --expectation-format`; parts of the output can
+be cutpasted into an `expected/` file to establish these needed known-good
+values.
 
 Caveats & Tips
 ==============

--- a/gips/test/sys/expected/modis.py
+++ b/gips/test/sys/expected/modis.py
@@ -91,7 +91,8 @@ t_info = { 'stdout':  u"""\x1b[1mGIPS Data Repositories (v0.8.2)\x1b[0m
 Modis Products v1.0.0\x1b[0m
 \x1b[1m
 Terra 8-day Products
-\x1b[0m   temp8td     Surface temperature: 1km                
+\x1b[0m   ndvi8       Normalized Difference Vegetation Index: 250m
+   temp8td     Surface temperature: 1km                
    temp8tn     Surface temperature: 1km                
 \x1b[1m
 Nadir BRDF-Adjusted 16-day Products
@@ -107,7 +108,6 @@ Terra/Aqua Daily Products
 Standard Products
 \x1b[0m   clouds      Cloud Mask                              
    landcover   MCD Annual Land Cover                   
-   ndvi8       Normalized Difference Vegetation Index: 250m
 """}
 
 t_project = { 'created': {


### PR DESCRIPTION
Here's what it looks like in situ:

```(.venv) laptop2:~/src/gips$ time pytest --sys -s --ll debug --expectation-format -k 'modis and info'
DEBUG    conftest.py:66: value detected for data-repo: /home/tolson/src/gips/data-root
===== test session starts =====
platform linux2 -- Python 2.7.12, pytest-3.0.4, py-1.4.31, pluggy-0.4.0
Django settings: gips.inventory.orm.settings (from ini file)
rootdir: /home/tolson/src/gips, inifile: pytest.ini
plugins: mock-1.4.0, django-3.1.1, timeout-1.2.0, cov-2.4.0
collected 136 items 

gips/test/sys/t_modis.py DEBUG    util.py:50: command line: `gips_info modis`
DEBUG    util.py:55: standard output: GIPS Data Repositories (v0.8.2)

Modis Products v1.0.0

Terra 8-day Products
   ndvi8       Normalized Difference Vegetation Index: 250m
   temp8td     Surface temperature: 1km                
   temp8tn     Surface temperature: 1km                

Nadir BRDF-Adjusted 16-day Products
   indices     Land indices                            
   quality     MCD Product Quality                     

Terra/Aqua Daily Products
   fsnow       Fractional snow cover data              
   obstime     MODIS Terra/Aqua overpass time          
   snow        Snow and ice cover data                 
   temp        Surface temperature data                

Standard Products
   clouds      Cloud Mask                              
   landcover   MCD Annual Land Cover                   

DEBUG    util.py:57: standard error: (None)
standard output (expectation format): """\x1b[1mGIPS Data Repositories (v0.8.2)\x1b[0m
\x1b[1m
Modis Products v1.0.0\x1b[0m
\x1b[1m
Terra 8-day Products
\x1b[0m   ndvi8       Normalized Difference Vegetation Index: 250m
   temp8td     Surface temperature: 1km                
   temp8tn     Surface temperature: 1km                
\x1b[1m
Nadir BRDF-Adjusted 16-day Products
\x1b[0m   indices     Land indices                            
   quality     MCD Product Quality                     
\x1b[1m
Terra/Aqua Daily Products
\x1b[0m   fsnow       Fractional snow cover data              
   obstime     MODIS Terra/Aqua overpass time          
   snow        Snow and ice cover data                 
   temp        Surface temperature data                
\x1b[1m
Standard Products
\x1b[0m   clouds      Cloud Mask                              
   landcover   MCD Annual Land Cover                   
"""
standard error (expectation format):  """"""
DEBUG    util.py:46: Created files: {}
DEBUG    util.py:46: Updated files: {}
DEBUG    util.py:46: Deleted files: {}
.

===== 135 tests deselected =====
===== 1 passed, 135 deselected in 2.17 seconds =====```