### PR TITLE
234 fetch, process, and E&A support in RQ for the datahandler

### DIFF
--- a/gips/datahandler/queue/queue.py
+++ b/gips/datahandler/queue/queue.py
@@ -44,10 +44,16 @@ def get_queue_module():
 
 
 def get_job_name(*args, **kwargs):
+    """Return the job's name as given by its queueing system."""
     # need to return an ascii string because, way down the line, gippy can't handle unicode
     return get_queue_module().get_job_name(*args, **kwargs).encode('ascii')
 
 def is_job_alive(*args, **kwargs):
+    """Returns True only if the job exists and is not yet completed.
+
+    This means that a 'living' job can running, or can be in a work queue but
+    not yet started.
+    """
     return get_queue_module().is_job_alive(*args, **kwargs)
 
 

--- a/gips/datahandler/queue/rq.py
+++ b/gips/datahandler/queue/rq.py
@@ -75,7 +75,7 @@ def submit(operation, call_signatures, chain=False):
         be worked in parallel depending on the RQ worker setup.
     """
     # TODO support everything
-    if operation not in ('query', 'fetch'):
+    if operation not in ('query', 'fetch', 'process'):
         raise NotImplementedError('Not all methods supported')
 
     q = get_queue()

--- a/gips/datahandler/queue/rq.py
+++ b/gips/datahandler/queue/rq.py
@@ -18,9 +18,35 @@ def get_job_name():
         raise queue.NoCurrentJobError('rq.get_current_job() returned None; no current job found')
     return job.id
 
+def is_job_alive(job_id):
+    """Tells whether the given job is currently running.
 
-def is_job_alive(sched_id):
-    raise NotImplementedError('NO support for this yet')
+    Job metadata in RQ has a TTL, so if no job matches the job ID,
+    False is returned because it's assumed the ID matched a job whose
+    metadata has since been removed from Redis.
+    """
+    job = get_queue().fetch_job(job_id)
+    return job is not None and job.is_started
+
+
+_queue = None
+
+def get_queue():
+    """Set up the RQ Queue object and return it.  Uses GIPS settings."""
+    # tell RQ what Redis connection to use
+    global _queue
+    if _queue is None:
+        redis_conn = redis.Redis(
+                host=utils.get_setting('RQ_REDIS_HOST', 'localhost'),
+                port=utils.get_setting('RQ_REDIS_PORT', 6379),
+                db=utils.get_setting('RQ_REDIS_DB', 0),
+                password=utils.get_setting('RQ_REDIS_PASSWORD', None)) # no password by default
+        _queue = rq.Queue(
+                name=utils.get_setting('RQ_QUEUE_NAME', 'datahandler'),
+                # copy 8h walltime from torque
+                default_timeout=utils.get_setting('RQ_TASK_TIMEOUT', 8 * 3600),
+                connection=redis_conn)
+    return _queue
 
 
 def work(operation, *args):
@@ -49,27 +75,14 @@ def submit(operation, call_signatures, chain=False):
         be worked in parallel depending on the RQ worker setup.
     """
     # TODO support everything
-    if operation != 'query':
-        raise NotImplementedError('query only for now (and even this is fake)')
-    if chain:
-        raise NotImplementedError('chain=True is a TODO')
+    if operation not in ('query', 'fetch'):
+        raise NotImplementedError('Not all methods supported')
 
-    # tell RQ what Redis connection to use
-    redis_conn = redis.Redis(
-            host=utils.get_setting('RQ_REDIS_HOST', 'localhost'),
-            port=utils.get_setting('RQ_REDIS_PORT', 6379),
-            db=utils.get_setting('RQ_REDIS_DB', 0),
-            password=utils.get_setting('RQ_REDIS_PASSWORD', None)) # no password by default
-    q = rq.Queue(
-            name=utils.get_setting('RQ_QUEUE_NAME', 'datahandler'),
-            # copy 8h walltime from torque
-            default_timeout=utils.get_setting('RQ_TASK_TIMEOUT', 8 * 3600),
-            connection=redis_conn)
-
-    # delay execution
+    q = get_queue()
     outcomes = []
+    job = None # prime the pump for chain=True
     for cs in call_signatures:
-        job = q.enqueue(work, operation, *cs)
+        job = q.enqueue(work, operation, *cs, depends_on=(job if chain else None))
         # reminder: cs[0] ought to be the primary key of a model in dbinv.models
         outcomes.append((job.id, cs[0]))
 

--- a/gips/datahandler/queue/rq.py
+++ b/gips/datahandler/queue/rq.py
@@ -26,7 +26,7 @@ def is_job_alive(job_id):
     metadata has since been removed from Redis.
     """
     job = get_queue().fetch_job(job_id)
-    return job is not None and job.is_started
+    return job is not None and (job.is_started or job.is_queued)
 
 
 _queue = None

--- a/gips/datahandler/worker.py
+++ b/gips/datahandler/worker.py
@@ -177,7 +177,7 @@ def _aggregate(job, outdir, nproc=1):
 
 def export_and_aggregate(job_id, start_ext, end_ext,
                          nprocs=1, outdir=None, cleanup=False, **mosaic_kwargs):
-    """Entirely TBD but does the same things as gips_project + zonal summary."""
+    """Does the same things as gips_project + zonal summary."""
     with transaction.atomic():
         job = dbinv.models.Job.objects.get(
             pk=job_id,

--- a/gips/inventory/dbinv/models.py
+++ b/gips/inventory/dbinv/models.py
@@ -174,11 +174,13 @@ class ProductStatusChange(models.Model):
 
 
 class DataVariable(models.Model):
-    """Inventory of Data Variables.
+    """Inventory of product types & metadata as specified by each driver.
 
-    Data variables are individual product bands specified by the driver
+    This table is a strict duplication of information that is stored in
+    gips/data/<driver>/<driver>.py, specifically class <driver>Data.  It
+    is usually referenced by the 'name' which will be programmatically
+    generated to be unique, eg 'modis_indices_lswi'.
     """
-
     name        = models.CharField(max_length=255, unique=True)
     asset_link  = models.TextField(null=True, blank=True)
     asset       = models.CharField(max_length=255, null=True, blank=True)


### PR DESCRIPTION
Semantic changes:
* rewrites to the scheduler to avoid race conditions
* make `get_job_name` always emit ascii for compatibility with gippy deep in the call stack
* `chain=True` support for `rq.submit()`
* implement `rq.is_job_alive(job_id)`
* make `queue.submit` always emit full call signatures as the scheduler expects.  

Refactoring & minor changes:
* `processing_status` should be just changing indentation.
* move RQ setup code to separate function for common use
* revert silly logging optimization
* improve various comments.

My manual test process was to run this code, then manually step through by running the scheduler repeatedly.  I observed correct-looking in both torque and rq modes.  Job submission snippet is:

```
shp_full_path = '/home/tolson/src/gips/gips/test/NHseacoast.shp'
gips.datahandler.api.submit_job('tolson-test-site', 'modis_fsnow_fractional-snow-cover',
    {'key':'shaid', 'site': shp_full_path}, {'dates': '2012-333,2012-335'})
```

And in other windows I had these running in my venv:

```
$ rq worker datahandler
$ python gips/datahandler/scripts/geokitd.py
```