### PR TITLE
Permit merra to use the DB inventory, and fix a prism tab bug

### DIFF
--- a/gips/data/prism/prism.py
+++ b/gips/data/prism/prism.py
@@ -250,10 +250,10 @@ class prismData(Data):
                     missingassets.append(asset)
                 else:
                     availassets.append(asset)
-                     vsinames[asset] = os.path.join(
-                         '/vsizip/' + self.assets[asset].filename,
-                         bil
-                     )
+                    vsinames[asset] = os.path.join(
+                        '/vsizip/' + self.assets[asset].filename,
+                        bil
+                    )
 
             if not availassets:
                 utils.verbose_out(

--- a/gips/inventory/orm/__init__.py
+++ b/gips/inventory/orm/__init__.py
@@ -34,7 +34,7 @@ def setup():
     if setup_complete:
         return
     if use_orm():
-        busted_drivers = ('sar', 'sarannual', 'modaod', 'merra', 'daymet', 'cdl')
+        busted_drivers = ('sar', 'sarannual', 'modaod', 'daymet', 'cdl')
         if driver_for_dbinv_feature_toggle in busted_drivers:
             msg = ("Inventory database does not support '{}'.  "
                    "Set GIPS_ORM=false to use the filesystem inventory instead.")


### PR DESCRIPTION
Unless I'm missing something, prism driver can't work in dev because of a bad line spacing. This change seems to make it OK for me.