### PR TITLE
Remove merra from orm blacklist, fix tabs in prism, fix daymet asset url, update pydap version

### DIFF
--- a/gips/data/daymet/daymet.py
+++ b/gips/data/daymet/daymet.py
@@ -74,7 +74,7 @@ class daymetAsset(Asset):
 
     _latency = 0
     _startdate = datetime.date(1980, 1, 1)
-    _url = "http://thredds.daac.ornl.gov/thredds/dodsC/ornldaac/1219/tiles/%d/%s_%d"
+    _url = "https://thredds.daac.ornl.gov/thredds/dodsC/ornldaac/1328/tiles/%d/%s_%d"
 
     _assets = {
         'tmin': {
@@ -144,7 +144,8 @@ class daymetAsset(Asset):
         y0 = dataset['y'].data[0] + 500.0
         day = date.timetuple().tm_yday
         iday = day - 1
-        data = np.array(dataset[asset][iday, :, :]).squeeze().astype('float32')
+        var = dataset[asset]
+        data = np.array(var.array[iday, :, :]).squeeze().astype('float32')
         ysz, xsz = data.shape
         description = cls._assets[asset]['description']
         meta = {'ASSET': asset, 'TILE': tile, 'DATE': str(date.date()), 'DESCRIPTION': description}

--- a/gips/data/prism/prism.py
+++ b/gips/data/prism/prism.py
@@ -250,10 +250,10 @@ class prismData(Data):
                     missingassets.append(asset)
                 else:
                     availassets.append(asset)
-                     vsinames[asset] = os.path.join(
-                         '/vsizip/' + self.assets[asset].filename,
-                         bil
-                     )
+                    vsinames[asset] = os.path.join(
+                        '/vsizip/' + self.assets[asset].filename,
+                        bil
+                    )
 
             if not availassets:
                 utils.verbose_out(

--- a/gips/inventory/orm/__init__.py
+++ b/gips/inventory/orm/__init__.py
@@ -34,7 +34,7 @@ def setup():
     if setup_complete:
         return
     if use_orm():
-        busted_drivers = ('sar', 'sarannual', 'modaod', 'merra', 'daymet', 'cdl')
+        busted_drivers = ('sar', 'sarannual', 'modaod', 'daymet', 'cdl')
         if driver_for_dbinv_feature_toggle in busted_drivers:
             msg = ("Inventory database does not support '{}'.  "
                    "Set GIPS_ORM=false to use the filesystem inventory instead.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ six>=1.9.0
 requests
 django==1.10
 netCDF4
-Pydap==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ six>=1.9.0
 requests
 django==1.10
 netCDF4
+Pydap==3.2.0

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         'shapely',
         'gippy>=0.3.8',
         'python-dateutil',
-        'pydap',
+        'pydap==3.2',
         'pysolar==0.6',
         'landsat-util==0.8.0ircwaves0',
     ],


### PR DESCRIPTION
Daymet was busted 

1 - The URL changed; now uses https, also the format of the url is different
2 - Pydap 3.2 accesses data differently; added to requirements.