### PR TITLE
254 zonal summary command-line program

### DIFF
--- a/gips/datahandler/scripts/geokitd.py
+++ b/gips/datahandler/scripts/geokitd.py
@@ -20,7 +20,7 @@ class ThreadedRPC(SocketServer.ThreadingMixIn, SimpleXMLRPCServer):
     pass
 
 class RequestHandler (SimpleXMLRPCRequestHandler):
-    rpc_paths = ('/RPC2',)
+    pass
 
 
 class LogRecordStreamHandler (SocketServer.StreamRequestHandler):
@@ -94,8 +94,13 @@ class LogRecordSocketReceiver (SocketServer.ThreadingTCPServer):
 
 
 def serve_log (host, port):
+    # TODO 3rd party libs log too, and don't pass in `extras`, so KeyError.  Fix by using one
+    # formatter for most logs, and a special one that shows jobid for worker logging.  Note also
+    # funcName:  datahandler.Logger.log() calls logging.log, so funcName is often just 'log', which
+    # isn't helpful.
     logging.basicConfig(format = (
-        '---- %(asctime)s %(jobid)s %(caller)s -----\n'
+        #'---- %(asctime)s %(jobid)s %(caller)s -----\n'
+        '---- %(asctime)s ---------- %(funcName)s ------\n'
         '%(message)s\n'
         '--------------------------------------------------------'
     ))

--- a/gips/parsers.py
+++ b/gips/parsers.py
@@ -78,16 +78,21 @@ class GIPSParser(argparse.ArgumentParser):
         group.add_argument('-s', '--site', help=h, default=None, required=site_required)
         h = 'Attribute to use as lookup in in vector file (defaults to index)'
         group.add_argument('-k', '--key', help=h, default="")
-        group.add_argument('-w', '--where', help="attribute=value pairs to limit features", default='')
+        group.add_argument('-w', '--where', help="attribute=value pairs to limit features",
+                           default='')
         group.add_argument('-t', '--tiles', nargs='*', help='Tile designations', default=None)
         group.add_argument('-d', '--dates', help='Range of dates (YYYY-MM-DD,YYYY-MM-DD)')
-        group.add_argument('--days', help='Include data within these days of year (doy1,doy2)', default=None)
+        group.add_argument('--days', help='Include data within these days of year (doy1,doy2)',
+                           default=None)
         group.add_argument('--sensors', help='Sensors to include', nargs='*', default=None)
-        group.add_argument('--%cov', dest='pcov', help='Threshold of %% tile coverage over site', default=0, type=int)
-        group.add_argument('--%tile', dest='ptile', help='Threshold of %% tile used', default=0, type=int)
+        group.add_argument('--%cov', dest='pcov', help='Threshold of %% tile coverage over site',
+                           default=0, type=int)
+        group.add_argument('--%tile', dest='ptile', help='Threshold of %% tile used', default=0,
+                           type=int)
         group.add_argument('--fetch', help='Fetch any missing data (if supported)',
                            default=False, action='store_true')
-        group.add_argument('--update', help='Force fetch and/ or update data (if supported)', default=False, action='store_true')
+        group.add_argument('--update', help='Force fetch and/ or update data (if supported)',
+                           default=False, action='store_true')
 
         group.add_argument('-p', '--products', help='Requested Products', nargs='*')
         self.parent_parsers.append(parser)
@@ -100,9 +105,11 @@ class GIPSParser(argparse.ArgumentParser):
         else:
             parser = self
         group = parser.add_argument_group('processing options')
-        group.add_argument('--overwrite', help='Overwrite existing output file(s)', default=False, action='store_true')
+        group.add_argument('--overwrite', help='Overwrite existing output file(s)',
+                           default=False, action='store_true')
         group.add_argument('--chunksize', help='Chunk size in MB', default=128.0, type=float)
-        group.add_argument('--numprocs', help='Desired number of processors (if allowed)', default=2, type=int)
+        group.add_argument('--numprocs', help='Desired number of processors (if allowed)',
+                           default=2, type=int)
         group.add_argument('--format', help='Format for output file', default="GTiff")
         h = ('Don\'t process. Instead, generate batch file with single '
              'gips_process command on each line.  \'overwrite\', '
@@ -121,7 +128,8 @@ class GIPSParser(argparse.ArgumentParser):
         group = parser.add_argument_group('project directory options')
         h = 'Directory to store project(s) (default to current directory)'
         group.add_argument('--outdir', help=h, default='')
-        group.add_argument('--suffix', help='Suffix to add to auto generated output directory', default='')
+        group.add_argument('--suffix', help='Suffix to add to auto generated output directory',
+                           default='')
         h = 'Do not create a top-level directory to hold project directories'
         group.add_argument('--notld', help=h, default=False, action='store_true')
         h = 'Create project directories in tree form'

--- a/gips/scripts/util.py
+++ b/gips/scripts/util.py
@@ -1,0 +1,30 @@
+from __future__ import print_function
+
+_verbosity = 1
+
+def set_verbosity(verbosity):
+    global _verbosity
+    _verbosity = verbosity
+
+def vprint(verbosity, *args, **kwargs):
+    """Like print() but with verbosity governance:
+
+    Pass in args and kwargs exactly like print(), except the first
+    argument must be a verbosity level, and a new optional kwarg, 'f',
+    can more conveniently set the output stream:
+
+    vprint(verbosity, value, ...,
+           sep=' ', end='\n', file=sys.stdout, f=['e'|'o'])
+
+    f=['o'|'e'] prints to stdout or stderr respectively.  Specifying
+    both 'f' and 'file' is ambiguous, so ValueError is raised in that
+    case.
+    """
+    # if needed rewrite kwargs['f'] to kwargs['file']
+    if 'f' in kwargs:
+        if 'file' in kwargs:
+            raise ValueError("Can't decide between f and file in kwargs")
+        kwargs['file'] = {'o': sys.stdout, 'e': sys.stderr}[kwargs.pop('f')]
+    if verbosity > _verbosity:
+        return
+    print(*args, **kwargs)

--- a/gips/scripts/zs.py
+++ b/gips/scripts/zs.py
@@ -20,9 +20,10 @@
 
 """Submit a zonal summary job to the gips data handler for remote execution.
 
-Several settings are needed for this; docs are TODO.  Example call:
+Several settings are needed for this; docs are TODO.  Example calls:
 
-    gips_zs modis ndvi /path/to/NHseacoast.shp 2012-12-01,2012-12-03 some.csv
+    gips_zs submit modis_indices_satvi /path/to/NHseacoast.shp 2012-12-01,2012-12-03
+    gips_zs status 937
 
 The shapefile and output file paths are in terms of the remote worker
 context; no file transport is supported.  A gips_zs invocation will
@@ -31,7 +32,7 @@ result in these remote tasks as needed:
   fetch:  download assets from the data provider, if needed
   process:  generate products from the assets (ndvi in this case), if needed
   export:  export products into the given shape
-  aggregate:  compute summary values for the exported data, save in CSV
+  aggregate:  compute summary values for the exported data
 """
 
 from __future__ import print_function
@@ -39,10 +40,20 @@ from __future__ import print_function
 import sys
 import os
 import argparse
+import xmlrpclib
 
 from gips import __version__ as gipsversion
+from gips import utils as gips_utils
+from gips.scripts import util
+from gips.scripts.util import vprint
 
 title = 'GIPS Zonal Summary (v' + gipsversion + ')'
+
+
+def rpc_conn():
+    """Return a connection to the RPC server; uses gips setting DH_API_SERVER."""
+    return xmlrpclib.ServerProxy(gips_utils.settings().DH_API_SERVER, use_datetime=True)
+
 
 def parse_args():
     """Parse command-line arguments via argparse."""
@@ -55,50 +66,86 @@ def parse_args():
     # set up for 'submit' command
     submit_p = sp.add_parser('submit', help='Submit a new job')
     [submit_p.add_argument(arg, help=desc) for arg, desc in (
-        ('provider', 'Choose the data source for the summary'),
-        ('product',  'Choose a product'),
-        ('site',     'Define geographic boundaries for the summary'),
-        ('dates',    'Range of dates (YYYY-MM-DD,YYYY-MM-DD)'),
-        ('outfile',  'Name of file in which to save CSV output'),
+        ('site_name', 'User-specified keyword or nickname; no computational purpose'),
+        ('data_spec', 'Combination of driver, product, and band'),
+        ('site',      'Define geographic boundaries for the summary'),
+        ('dates',     'Range of dates (YYYY-MM-DD,YYYY-MM-DD)'),
     )]
 
     # set up for 'status' command
     status_p = sp.add_parser('status', help='Show status of an existing job')
-    status_p.add_argument('jobid', help='ID of the job to check up on')
+    status_p.add_argument('job_id', help='ID of the job to check up on')
 
     # both commands need --verbose; for this simple case parents=[..] isn't worthy
     for p in submit_p, status_p:
         p.add_argument('-v', '--verbose', help='Verbosity - 0: quiet, 1: normal, 2+: debug',
                        default=1, type=int, choices=range(0, 7))
 
-    return cmd_parser.parse_args()
+    # parse, report, return
+    args = cmd_parser.parse_args()
+    util.set_verbosity(args.verbose)
+    vprint(2, 'Verbosity level:', args.verbose)
+    vprint(3, 'Arguments & options:')
+    vprint(3, '  command:', args.cmd)
+    if args.cmd == 'submit':
+        vprint(3, '  site_name:', args.site_name)
+        vprint(3, '  data_spec:', args.data_spec)
+        vprint(3, '  site:', args.site)
+        vprint(3, '  dates:', args.dates)
+    elif args.cmd == 'status':
+        vprint('  job_id:', args.job_id)
+    else:
+        raise RuntimeError('Unreachable line reached')
+    return args
+
+
+def submit(site_name, data_spec, site, dates):
+    """Performs job submissions, returns the job id."""
+    job_id = rpc_conn().submit_job(site_name, data_spec,
+                                   {'site': site, 'key': 'shaid'}, {'dates': dates})
+    vprint(0, 'Job submitted; job ID:', job_id)
+
+
+def status(job_id):
+    """Performs status check; returns current status."""
+    # TODO handle cases(?):
+    #   no such job
+    #   finished & succeeded - and show the outcome data
+    #   finished & failed
+    #   job is ongoing
+    results = rpc_conn().stats_request_results({'job': job_id})
+    # expected results:
+    '''
+    [
+        { . . . }, # one dict per day
+        {
+            'count': 10118,
+            'skew': -4.1808,
+            'maximum': 0.7466,
+            'site': '',
+            'job': 68,
+            'minimum': -1.0002,
+            `date': datetime.datetime(2013, 4, 28, 0, 0),
+            'mean': 0.541821,
+            'shaid': '1',
+            'id': 1487043,
+            'sd': 0.105745,
+        },
+    ]
+    '''
+    vprint(results)
 
 
 def main():
-    args = parse_args()
+    vprint(1, title)
+    a = parse_args()
 
-    print(title)
-
-    if args.verbose > 1:
-        print('Arguments & options:')
-        print('  command:', args.cmd)
-        if args.cmd == 'submit':
-            print('  provider:', args.provider)
-            print('  product:', args.product)
-            print('  site:', args.site)
-            print('  dates:', args.dates)
-            print('  outfile:', args.outfile)
-        elif args.cmd == 'status':
-            print('  jobid:', args.jobid)
-        else:
-            raise RuntimeError('Unreachable line reached')
-        print('  verbose:', args.verbose)
-
-    # TODO:
-    #   submit:  no blocking on job completion; it outputs a job id
-    #   status:  input job id, output is status report
-
-    raise NotImplementedError('UX framing is ready but implementation is not.')
+    if a.cmd == 'submit':
+        submit(a.site_name, a.data_spec, a.site, a.dates)
+    elif a.cmd == 'status':
+        status(a.job_id)
+    else:
+        raise RuntimeError('Unreachable line reached')
 
 
 if __name__ == "__main__":

--- a/gips/scripts/zs.py
+++ b/gips/scripts/zs.py
@@ -41,6 +41,8 @@ import sys
 import os
 import argparse
 import xmlrpclib
+import csv
+import pprint
 
 from gips import __version__ as gipsversion
 from gips import utils as gips_utils
@@ -61,7 +63,7 @@ def parse_args():
     epilog = 'For help on each command: {} {{submit,status}} -h'.format(
             os.path.basename(sys.argv[0]))
     cmd_parser = argparse.ArgumentParser(description=title, epilog=epilog)
-    sp = cmd_parser.add_subparsers(dest='cmd', help='Whether to submit or check on job')
+    sp = cmd_parser.add_subparsers(dest='cmd', help='Choose an operation')
 
     # set up for 'submit' command
     submit_p = sp.add_parser('submit', help='Submit a new job')
@@ -76,8 +78,14 @@ def parse_args():
     status_p = sp.add_parser('status', help='Show status of an existing job')
     status_p.add_argument('job_id', help='ID of the job to check up on')
 
-    # both commands need --verbose; for this simple case parents=[..] isn't worthy
-    for p in submit_p, status_p:
+    # set up for 'result' command
+    result_p = sp.add_parser('result', help='Print job results, if available')
+    result_p.add_argument('job_id', help='ID of the job to check up on')
+    result_p.add_argument('-f', '--file', help='Destination for CSV results (default: stdout)',
+                       default=sys.stdout)
+
+    # all commands need --verbose; for this simple case parents=[..] isn't worthy
+    for p in submit_p, status_p, result_p:
         p.add_argument('-v', '--verbose', help='Verbosity - 0: quiet, 1: normal, 2+: debug',
                        default=1, type=int, choices=range(0, 7))
 
@@ -87,15 +95,7 @@ def parse_args():
     vprint(2, 'Verbosity level:', args.verbose)
     vprint(3, 'Arguments & options:')
     vprint(3, '  command:', args.cmd)
-    if args.cmd == 'submit':
-        vprint(3, '  site_name:', args.site_name)
-        vprint(3, '  data_spec:', args.data_spec)
-        vprint(3, '  site:', args.site)
-        vprint(3, '  dates:', args.dates)
-    elif args.cmd == 'status':
-        vprint('  job_id:', args.job_id)
-    else:
-        raise RuntimeError('Unreachable line reached')
+    vprint(3, pprint.pformat(vars(args)))
     return args
 
 

--- a/gips/scripts/zs.py
+++ b/gips/scripts/zs.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+################################################################################
+#    GIPS: Geospatial Image Processing System
+#
+#    Copyright (C) 2014 Applied Geosolutions
+#
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see <http://www.gnu.org/licenses/>
+################################################################################
+
+"""Submit a zonal summary job to the gips data handler for remote execution.
+
+Several settings are needed for this; docs are TODO.  Example call:
+
+    gips_zs modis ndvi /path/to/NHseacoast.shp 2012-12-01,2012-12-03 some.csv
+
+The shapefile and output file paths are in terms of the remote worker
+context; no file transport is supported.  A gips_zs invocation will
+result in these remote tasks as needed:
+  query:  determine which assets and products are needed
+  fetch:  download assets from the data provider, if needed
+  process:  generate products from the assets (ndvi in this case), if needed
+  export:  export products into the given shape
+  aggregate:  compute summary values for the exported data, save in CSV
+"""
+
+from __future__ import print_function
+
+import sys
+import os
+import argparse
+
+from gips import __version__ as gipsversion
+
+title = 'GIPS Zonal Summary (v' + gipsversion + ')'
+
+def parse_args():
+    """Parse command-line arguments via argparse."""
+    # not using gips.parsers due to semantic mismatch and correctness issues
+    epilog = 'For help on each command: {} {{submit,status}} -h'.format(
+            os.path.basename(sys.argv[0]))
+    cmd_parser = argparse.ArgumentParser(description=title, epilog=epilog)
+    sp = cmd_parser.add_subparsers(dest='cmd', help='Whether to submit or check on job')
+
+    # set up for 'submit' command
+    submit_p = sp.add_parser('submit', help='Submit a new job')
+    [submit_p.add_argument(arg, help=desc) for arg, desc in (
+        ('provider', 'Choose the data source for the summary'),
+        ('product',  'Choose a product'),
+        ('site',     'Define geographic boundaries for the summary'),
+        ('dates',    'Range of dates (YYYY-MM-DD,YYYY-MM-DD)'),
+        ('outfile',  'Name of file in which to save CSV output'),
+    )]
+
+    # set up for 'status' command
+    status_p = sp.add_parser('status', help='Show status of an existing job')
+    status_p.add_argument('jobid', help='ID of the job to check up on')
+
+    # both commands need --verbose; for this simple case parents=[..] isn't worthy
+    for p in submit_p, status_p:
+        p.add_argument('-v', '--verbose', help='Verbosity - 0: quiet, 1: normal, 2+: debug',
+                       default=1, type=int, choices=range(0, 7))
+
+    return cmd_parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    print(title)
+
+    if args.verbose > 1:
+        print('Arguments & options:')
+        print('  command:', args.cmd)
+        if args.cmd == 'submit':
+            print('  provider:', args.provider)
+            print('  product:', args.product)
+            print('  site:', args.site)
+            print('  dates:', args.dates)
+            print('  outfile:', args.outfile)
+        elif args.cmd == 'status':
+            print('  jobid:', args.jobid)
+        else:
+            raise RuntimeError('Unreachable line reached')
+        print('  verbose:', args.verbose)
+
+    # TODO:
+    #   submit:  no blocking on job completion; it outputs a job id
+    #   status:  input job id, output is status report
+
+    raise NotImplementedError('UX framing is ready but implementation is not.')
+
+
+if __name__ == "__main__":
+    main()

--- a/gips/utils.py
+++ b/gips/utils.py
@@ -180,7 +180,8 @@ def get_setting(setting, default=None):
     """Fetch a GIPS setting named by the given string.
 
     If the setting isn't present in gips settings, the default is
-    returned instead.
+    returned instead.  If an exception should be raised due to absence
+    of the given setting, settings().SETTING should be used instead.
     """
     return settings().__dict__.get(setting, default)
 


### PR DESCRIPTION
New command-line program, `gips_zs`, for calling the datahandler's API remotely:

```
$ gips_zs --help
GIPS Zonal Summary (v0.8.2)
usage: gips_zs submit [-h] [-v {0,1,2,3,4,5,6}] site_name data_spec site dates

positional arguments:
  site_name             User-specified keyword or nickname; no computational
                        purpose
  data_spec             Combination of driver, product, and band
  site                  Define geographic boundaries for the summary
  dates                 Range of dates (YYYY-MM-DD,YYYY-MM-DD)

optional arguments:
  -h, --help            show this help message and exit
  -v {0,1,2,3,4,5,6}, --verbose {0,1,2,3,4,5,6}
                        Verbosity - 0: quiet, 1: normal, 2+: debug
$ gips_zs status --help
GIPS Zonal Summary (v0.8.2)
usage: gips_zs status [-h] [-v {0,1,2,3,4,5,6}] job_id

positional arguments:
  job_id                ID of the job to check up on

optional arguments:
  -h, --help            show this help message and exit
  -v {0,1,2,3,4,5,6}, --verbose {0,1,2,3,4,5,6}
                        Verbosity - 0: quiet, 1: normal, 2+: debug
$ gips_zs result --help
GIPS Zonal Summary (v0.8.2)
usage: gips_zs result [-h] [-f FILE] [-v {0,1,2,3,4,5,6}] job_id

positional arguments:
  job_id                ID of the job to check up on

optional arguments:
  -h, --help            show this help message and exit
  -f FILE, --file FILE  Destination for CSV results (default: stdout)
  -v {0,1,2,3,4,5,6}, --verbose {0,1,2,3,4,5,6}
                        Verbosity - 0: quiet, 1: normal, 2+: debug
```

Example session:

```
$ gips_zs submit 254-test-site modis_indices_ndvi /home/tolson/src/gips/gips/test/NHseacoast.shp -v6 2013-119
GIPS Zonal Summary (v0.8.2)
Verbosity level: 6
Arguments & options:
  command: submit
{'cmd': 'submit',
 'data_spec': 'modis_indices_ndvi',
 'dates': '2013-119',
 'site': '/home/tolson/src/gips/gips/test/NHseacoast.shp',
 'site_name': '254-test-site',
 'verbose': 6}
Job submitted; job ID: 2
$ gips_zs status 2
GIPS Zonal Summary (v0.8.2)
Product Status:
  requested      1
  scheduled      0
  in-progress    0
  complete       0
  failed         0
Job Status: in-progress
$ gips_zs result 2  # . . . later after job completion; CSV output defaults to stdout
GIPS Zonal Summary (v0.8.2)
id,job,date,site,count,minimum,maximum,mean,skew,sd,shaid
2,2,2013-04-29 00:00:00,,10118,-0.9874,0.7484,0.545754,-3.59946,0.102561,1
$ # results are stateless once computed, so one can save them multiple times:
$ gips_zs result 2 -f job2.csv && echo 'JOB 2 CSV:' && cat job2.csv
GIPS Zonal Summary (v0.8.2)
JOB 2 CSV:
id,job,date,site,count,minimum,maximum,mean,skew,sd,shaid
2,2,2013-04-29 00:00:00,,10118,-0.9874,0.7484,0.545754,-3.59946,0.102561,1
