### PR TITLE
fix modis fetch TypeError

### DIFF
--- a/gips/data/modis/modis.py
+++ b/gips/data/modis/modis.py
@@ -183,9 +183,10 @@ class modisAsset(Asset):
     def query_service(cls, asset, tile, date):
         year, month, day = date.timetuple()[:3]
 
-        if asset == "MCD12Q1" and (month != 1 or day != 1):
-            print("Land cover data are only available for Jan. 1")
-            return
+        if asset == "MCD12Q1" and (month, day) != (1, 1):
+            utils.verbose_out("Cannot fetch MCD12Q1:  Land cover data"
+                              " are only available for Jan. 1", 1, stream=sys.stderr)
+            return []
 
         # if it's going to fail, let's find out early:
         http_query = {'timeout': 30}

--- a/gips/test/sys/t_modis.py
+++ b/gips/test/sys/t_modis.py
@@ -28,15 +28,13 @@ def setup_modis_data(pytestconfig):
     outcome = envoy.run(cmd_str)
     logger.info("MODIS data download complete.")
     if outcome.status_code != 0:
-        msg = ("MODIS data setup via `gips_inventory` technically failed, but this may be due to false"
-               " positives in the driver; proceeding with tests")
-        logger.warning(msg)
-        logger.warning('=== standard out:  ' + outcome.std_out)
-        logger.warning('=== standard error:  ' + outcome.std_err)
-        # this is why we can't have nice things:  modis now uses a sensible nonzero exit status if
-        # one of its fetches fail, but it continues to attempt fetches that can't possibly succeed
-        # due to data unavailability.
-        # raise RuntimeError(msg, outcome.std_out, outcome.std_err, outcome)
+        #msg = ("MODIS data setup via `gips_inventory` technically failed, but this may be due to false"
+        #       " positives in the driver; proceeding with tests")
+        #logger.warning(msg)
+        #logger.warning('=== standard out:  ' + outcome.std_out)
+        #logger.warning('=== standard error:  ' + outcome.std_err)
+        raise RuntimeError("MODIS data setup via `gips_inventory` failed",
+                           outcome.std_out, outcome.std_err, outcome)
 
 
 def t_inventory(setup_modis_data, repo_env, expected):


### PR DESCRIPTION
`return` is `return None` which makes `modisAsset.fetch` croak because it expects the output of `query_service` to be iterable.  Fixed by returning `[]`.  This in turn made the modis `--setup-repo` bit in the sys tests work without needing to wimp out about the exit status.