### PR TITLE
127 add assets to datahandler.api.get_status:

### DIFF
--- a/gips/datahandler/scheduler.py
+++ b/gips/datahandler/scheduler.py
@@ -223,11 +223,11 @@ def schedule_export_and_aggregate ():
         status='in-progress',
     )
     for job in jobs:
-        status = api.processing_status(
+        status = api.status_counts(
             job.variable.driver.encode('ascii', 'ignore'),
             eval(job.spatial),
             eval(job.temporal),
-            [job.variable.product.encode('ascii', 'ignore')],
+            products=[job.variable.product.encode('ascii', 'ignore')],
         )
         if (
                 status['requested'] == 0

--- a/gips/inventory/dbinv/models.py
+++ b/gips/inventory/dbinv/models.py
@@ -43,6 +43,11 @@ failed          Asset       set by scheduler when retry count exceeds hardcoded 
                 Job         set on the parent Job of a PPJ when its E&A task is marked failed
 """
 
+status_values = {
+    'asset':   ('requested', 'scheduled', 'in-progress', 'complete', 'retry', 'failed'),
+    'product': ('requested', 'scheduled', 'in-progress', 'complete', 'retry', 'failed'),
+}
+
 status_strings = ('remote',
                   'requested',
                   'initializing',  # this is only used at the job level


### PR DESCRIPTION
Rewrite processing_status into status_counts, which reports on assets,
products, or both, at the caller's option.  Report both for get_status
but keep just-products for the use of the scheduler's
export-and-aggregate function.  Add valid status dict to models.py so
that get_status doesn't have to filter.