### PR TITLE
fix products error during query step:

### DIFF
--- a/gips/core.py
+++ b/gips/core.py
@@ -142,8 +142,11 @@ class SpatialExtent(object):
 
 
 class TemporalExtent(object):
-    """ Description of temporal extent """
+    """Two dates and a little method convenience, wrapped in a class.
 
+    The dates are represented internally by self.datebounds ==
+    (year1, year2) and self.daybounds == (day_of_year1, day_of_year2).
+    """
     def __init__(self, dates=None, days=None):
         """ Create temporal extent object from string input """
         if dates is None:
@@ -163,8 +166,6 @@ class TemporalExtent(object):
 
         self.datebounds = dates
         self.daybounds = days
-        self.datearray = []
-        #self.dates = [d for t in tiles for d in repo.find_dates(t) if datecheck(d) and daycheck(d)]
 
     def prune_dates(self, dates):
         """ Prune down given list of dates to those that meet temporal extent """


### PR DESCRIPTION
If assets exist for a product, the product isn't added to the database.
Fix this by moving product creation in the DB to its own loop, wherein
it looks up what assets are expected to be available.  Remove pointless
attribute from TemporalExtent.  Improve docstrings.