### PR TITLE
286 failure tracking

### DIFF
--- a/gips/datahandler/scheduler.py
+++ b/gips/datahandler/scheduler.py
@@ -175,15 +175,16 @@ def schedule_process ():
     prerequisite assets are in place.
     """
     orm.setup()
-    # fail any products with failed dependencies, otherwise they'd languish forever
-    with transaction.atomic():
-        # need distinct() because asset-product relation is many-to-many
-        doomed = dbinv.models.Product.objects.filter(
-                status='requested', assetdependency__asset__status='failed').distinct()
-        if doomed.exists():
-            Logger().log(
-                    "{} products failed due to failed asset dependencies".format(doomed.count()))
-            dbinv.models.update_status(doomed, 'failed')
+    # fail any products with failed dependencies; commented out while better solution is chosen
+    # details:  https://github.com/Applied-GeoSolutions/gips/pull/292
+    #with transaction.atomic():
+    #    # need distinct() because asset-product relation is many-to-many
+    #    doomed = dbinv.models.Product.objects.filter(
+    #            status='requested', assetdependency__asset__status='failed').distinct()
+    #    if doomed.exists():
+    #        Logger().log(
+    #                "{} products failed due to failed asset dependencies".format(doomed.count()))
+    #        dbinv.models.update_status(doomed, 'failed')
 
     psfu = dbinv.models.Product.objects.select_for_update
 


### PR DESCRIPTION
Fail jobs with failed assets or products.  Fail products that have failed asset dependencies.

I wanted to re-use the select-for-update bit for both finding products to fail and finding products to schedule, but alas, select-for-update is incompeatible with `distinct()`, which is needed to report accurately on how many products failed (due to join duplicating products in resulting queryset).