### PR TITLE
services no longer missing

### DIFF
--- a/install_datahandler.py
+++ b/install_datahandler.py
@@ -11,7 +11,7 @@ from glob import glob
 from commands import getstatusoutput
 
 
-GIPS_VERSION = "bs-deploy-lxc-edit" # branch or tag to install from
+GIPS_VERSION = "291-missing-services" # branch or tag to install from
 
 LSB_INFO = lsb.get_lsb_information()
 
@@ -302,10 +302,10 @@ def main():
         PKGS += DH_TORQUE_PKGS
     else:
         raise Exception('Unknown task-queue specified "{}"'.format(task_queue))
-    
+
     if args['install_pg']:
         PKGS += PG_PKGS
-        
+
     install_system_requirements(PKGS)
 
     if args['create_db']:

--- a/install_datahandler.py
+++ b/install_datahandler.py
@@ -129,7 +129,10 @@ def setup_postgresql(db_host, db_name, db_user, db_password, **kwargs):
     )
     for cmd in [user_add, db_create, grant_priv]:
         print('running: ' + cmd)
+        prev_dir = os.path.abspath(os.curdir)
+        os.chdir('/')
         status, output = getstatusoutput(cmd)
+        os.chdir(prev_dir)
         if status != 0:
             raise Exception(output)
         print(output)

--- a/install_datahandler.py
+++ b/install_datahandler.py
@@ -11,7 +11,7 @@ from glob import glob
 from commands import getstatusoutput
 
 
-GIPS_VERSION = "291-missing-services" # branch or tag to install from
+GIPS_VERSION = "datahandler" # branch or tag to install from
 
 LSB_INFO = lsb.get_lsb_information()
 

--- a/lxc.sh
+++ b/lxc.sh
@@ -11,6 +11,10 @@
 # endif
 # + restores the container to its `pipped` snapshot
 # +
+#
+# ARGUEMENTS
+# $1 -- a git branch or tag to install
+
 set -e
 CONT=dh
 SNAP=pipped
@@ -48,6 +52,10 @@ read -p "Enter your NASA EarthData password: " EDPASS
 echo ''
 create_or_reset_container
 lxc file push install_datahandler.py $CONT/root/
+EXTRA_ARGS=""
+if [ "${1}" ] ; then
+    EXTRA_ARGS="-G ${1} "
+fi
 lxc exec $CONT -- python /root/install_datahandler.py \
     --drivers modis merra \
     --earthdata-user $EDUSER \
@@ -55,4 +63,5 @@ lxc exec $CONT -- python /root/install_datahandler.py \
     --enable-cron \
     --install-pg \
     --create-db \
-    --enable-daemons
+    --enable-daemons \
+    ${EXTRA_ARGS}

--- a/lxc.sh
+++ b/lxc.sh
@@ -14,7 +14,7 @@
 set -e
 CONT=dh
 {
-    lxc info $CONT 2>&1>/dev/null || {
+    lxc info $CONT 2>/dev/null 1>/dev/null || {
         time lxc launch ubuntu-daily:16.04 $CONT
         sleep 10
         lxc exec $CONT -- apt-get update
@@ -24,15 +24,19 @@ CONT=dh
         lxc exec $CONT -- apt-get install -y gfortran libboost-all-dev libfreetype6-dev libgnutls-dev libatlas-base-dev libgdal-dev libgdal1-dev gdal-bin python-numpy python-scipy python-gdal swig2.0
         lxc exec $CONT -- pip install -U pip
     }
-    #echo "1"
-    #lxc info $CONT | grep Snapshots > /dev/null && echo "2" &&
-    #    { echo "3" ; lxc restore $CONT pipped ; echo "4" ; } ||
-    #        { echo "5" ; lxc snapshot $CONT pipped ; echo "6" ; }
+    echo "1"
+    lxc info $CONT | grep Snapshots > /dev/null && echo "2" &&
+       { echo "3" ; lxc restore $CONT pipped ; echo "4" ; } ||
+           { echo "5" ; lxc snapshot $CONT pipped ; echo "6" ; }
     if $(lxc list $CONT | grep STOPPED) ; then
         lxc start $CONT
         sleep 1
     fi
 }
+read -sp "Enter your NASA EarthData username: " EDUSER
+echo ''
+read -sp "Enter your NASA EarthData password: " EDPASS
+echo ''
 lxc file push install_datahandler.py $CONT/root/
 lxc exec $CONT -- python /root/install_datahandler.py \
     --drivers modis merra \
@@ -40,4 +44,5 @@ lxc exec $CONT -- python /root/install_datahandler.py \
     --earthdata-password $EDPASS \
     --enable-cron \
     --install-pg \
+    --create-db \
     --enable-daemons

--- a/lxc.sh
+++ b/lxc.sh
@@ -38,13 +38,13 @@ function create_or_reset_container() {
     fi
     if $(lxc list $CONT | grep STOPPED) ; then
         lxc start $CONT
-        sleep 1
+        sleep 5
     fi
 }
 
-read -sp "Enter your NASA EarthData username: " EDUSER
+read -p "Enter your NASA EarthData username: " EDUSER
 echo ''
-read -sp "Enter your NASA EarthData password: " EDPASS
+read -p "Enter your NASA EarthData password: " EDPASS
 echo ''
 create_or_reset_container
 lxc file push install_datahandler.py $CONT/root/

--- a/lxc.sh
+++ b/lxc.sh
@@ -13,9 +13,11 @@
 # +
 set -e
 CONT=dh
-{
+SNAP=pipped
+
+function create_or_reset_container() {
     lxc info $CONT 2>/dev/null 1>/dev/null || {
-        time lxc launch ubuntu-daily:16.04 $CONT
+        lxc launch ubuntu-daily:16.04 $CONT
         sleep 10
         lxc exec $CONT -- apt-get update
         sleep 10
@@ -23,20 +25,28 @@ CONT=dh
         # extra due to strange apt fetching issue
         lxc exec $CONT -- apt-get install -y gfortran libboost-all-dev libfreetype6-dev libgnutls-dev libatlas-base-dev libgdal-dev libgdal1-dev gdal-bin python-numpy python-scipy python-gdal swig2.0
         lxc exec $CONT -- pip install -U pip
-    }
-    echo "1"
-    lxc info $CONT | grep Snapshots > /dev/null && echo "2" &&
-       { echo "3" ; lxc restore $CONT pipped ; echo "4" ; } ||
-           { echo "5" ; lxc snapshot $CONT pipped ; echo "6" ; }
+    } ;
+
+    HAVE_SNAP=$(lxc info $CONT | grep ${SNAP} || true)
+    echo "HAVE_SNAP: $HAVE_SNAP"
+    if [ "$HAVE_SNAP" ] ; then
+        lxc restore $CONT $SNAP ;
+        echo "$CONT restored to snapshot $SNAP"
+    else
+        lxc snapshot $CONT $SNAP ;
+        echo "$CONT snapshot taken as $SNAP"
+    fi
     if $(lxc list $CONT | grep STOPPED) ; then
         lxc start $CONT
         sleep 1
     fi
 }
+
 read -sp "Enter your NASA EarthData username: " EDUSER
 echo ''
 read -sp "Enter your NASA EarthData password: " EDPASS
 echo ''
+create_or_reset_container
 lxc file push install_datahandler.py $CONT/root/
 lxc exec $CONT -- python /root/install_datahandler.py \
     --drivers modis merra \

--- a/setup.py
+++ b/setup.py
@@ -85,8 +85,8 @@ setup(
     maintainer_email='icooke@ags.io',
     packages=find_packages(),
     package_data={
-        '': ['*.shp', '*.prj', '*.shx', '*.dbf']
-        'gips.datahandler': ['*.service.template',]
+        '': ['*.shp', '*.prj', '*.shx', '*.dbf'],
+        'gips.datahandler': ['*.service.template',],
     },
     install_requires=_lib_requirements,
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,10 @@ setup(
     maintainer='Ian Cooke',
     maintainer_email='icooke@ags.io',
     packages=find_packages(),
-    package_data={'': ['*.shp', '*.prj', '*.shx', '*.dbf']},
+    package_data={
+        '': ['*.shp', '*.prj', '*.shx', '*.dbf']
+        'gips.datahandler': ['*.service.template',]
+    },
     install_requires=_lib_requirements,
     extras_require={
         'full': _full_requirements,


### PR DESCRIPTION
fixes #291 by as described in that issue.

also `lxc.sh` should now be usable as intended, the blocker to it running with a fresh container was that no commands can fail when you use `set -e`, and the `lxc info $CONT | grep $SNAP` was failing.  `set -e` is important for actually finding out that you had an error in a bash script, instead of it just marching on and failing all over the place in a confusing manner.

Could whoever reviews this please **NOT** merge, I'd like to change the `lxc.sh` defaults before merging.