### PR TITLE
#304 tempdir method & prism implementation

### DIFF
--- a/gips/data/core.py
+++ b/gips/data/core.py
@@ -642,11 +642,12 @@ class Data(object):
         """
         self.id = tile
         self.date = date
-        self.path = path
-        self.basename = ''              # product file name prefix, form is <tile>_<date>
-        self.assets = {}                # dict of <asset type string>: <Asset instance>
-        self.filenames = {}             # dict of (sensor, product): product filename
-        self.sensors = {}               # dict of asset/product: sensor
+        self.path = path      # /full/path/to/{driver}/tiles/{tile}/{date}; overwritten below
+        self.basename = ''    # product file name prefix, form is <tile>_<date>
+        self.assets = {}      # dict of <asset type string>: <Asset instance>
+        self.filenames = {}   # dict of (sensor, product): product filename
+        self.sensors = {}     # dict of asset/product: sensor
+        # self.basename       # self.path + part of a product filename; used as a prefix; set below
         if tile is not None and date is not None:
             self.path = self.Repository.data_path(tile, date)
             self.basename = self.id + '_' + self.date.strftime(self.Repository._datedir)

--- a/gips/data/core.py
+++ b/gips/data/core.py
@@ -316,8 +316,7 @@ class Asset(object):
             files = utils.find_files(cls._assets[a]['pattern'], tpath)
             # more than 1 asset??
             if len(files) > 1:
-                VerboseOut(files, 2)
-                raise Exception("Duplicate(?) assets found")
+                raise Exception("Duplicate(?) assets found: {}".format(files))
             if len(files) == 1:
                 found.append(cls(files[0]))
         return found
@@ -535,7 +534,8 @@ class Data(object):
         """ Make sure all products exist and return those that need processing """
         # TODO calling RequestedProducts twice is strange; rework into something clean
         products = self.RequestedProducts(products)
-        products = self.RequestedProducts([p for p in products.products if p not in self.products or overwrite])
+        products = self.RequestedProducts(
+                [p for p in products.products if p not in self.products or overwrite])
         # TODO - this doesnt know that some products aren't available for all dates
         return products
 

--- a/gips/data/core.py
+++ b/gips/data/core.py
@@ -549,7 +549,8 @@ class Data(object):
         """ Process composite products using provided inventory """
         pass
 
-    def copy(self, dout, products, site=None, res=None, interpolation=0, crop=False, overwrite=False, tree=False):
+    def copy(self, dout, products, site=None, res=None, interpolation=0, crop=False,
+             overwrite=False, tree=False):
         """ Copy products to new directory, warp to projection if given site.
 
         Arguments
@@ -755,9 +756,6 @@ class Data(object):
             dbinv.update_or_add_product(driver=self.name.lower(), product=product, sensor=sensor,
                                         tile=self.id, date=self.date, name=filename)
 
-
-
-
     def asset_filenames(self, product):
         assets = self._products[product]['assets']
         filenames = []
@@ -861,7 +859,8 @@ class Data(object):
         """ Return list of inventories (size 1 if not looping through geometries) """
         from gips.inventory import DataInventory
         from gips.core import SpatialExtent, TemporalExtent
-        spatial = SpatialExtent.factory(cls, site=site, key=key, where=where, tiles=tiles, pcov=pcov, ptile=ptile)
+        spatial = SpatialExtent.factory(cls, site=site, key=key, where=where, tiles=tiles,
+                                        pcov=pcov, ptile=ptile)
         temporal = TemporalExtent(dates, days)
         return DataInventory(cls, spatial[0], temporal, **kwargs)
 
@@ -944,3 +943,12 @@ class Data(object):
             print "  Optional qualifiers listed below each product."
             print "  Specify by appending '-option' to product (e.g., ref-toa)"
         sys.stdout.write(txt)
+
+    def make_temp_proc_dir(self):
+        """Make a temporary directory in which to perform gips processing.
+
+        Returns a context manager that governs the newly-made directory,
+        which is deleted on exiting the context. It is created in the
+        driver's stage directory, and has a random name.
+        """
+        return utils.make_temp_dir(prefix='proc', dir=self.Repository.path('stage'))

--- a/gips/data/prism/prism.py
+++ b/gips/data/prism/prism.py
@@ -66,19 +66,19 @@ class prismAsset(Asset):
     # 1 week for provisional
     _assets = {
         '_ppt': {
-            'pattern': r'PRISM_ppt_.+?\.zip',
+            'pattern': r'PRISM_ppt_.+?\.zip$',
             'url': 'ftp://prism.nacse.org/daily/ppt/',
             'startdate': _startdate,
             'latency': -7
         },
         '_tmin': {
-            'pattern': r'PRISM_tmin_.+?\.zip',
+            'pattern': r'PRISM_tmin_.+?\.zip$',
             'url': 'ftp://prism.nacse.org/daily/tmin/',
             'startdate': _startdate,
             'latency': -7
         },
         '_tmax': {
-            'pattern': r'PRISM_tmax_.+?\.zip',
+            'pattern': r'PRISM_tmax_.+?\.zip$',
             'url': 'ftp://prism.nacse.org/daily/tmax/',
             'startdate': _startdate,
             'latency': -7
@@ -213,10 +213,7 @@ class prismData(Data):
     }
 
     def process(self, *args, **kwargs):
-        """Make sure all products exist and return those that need processing.
-
-        (docstring cribbed from super.)
-        """
+        """Deduce which products need producing, then produce them."""
         products = super(prismData, self).process(*args, **kwargs)
         if len(products) == 0:
             return

--- a/gips/test/int/t_core.py
+++ b/gips/test/int/t_core.py
@@ -1,0 +1,19 @@
+"""Integration tests for core functions, such as those found in gips.core and gips.data.core."""
+
+import os
+
+from gips.data.landsat import landsat
+
+def t_make_temp_proc_dir():
+    """Test Data.make_temp_proc_dir:
+
+    Confirm creation of tempdir in stage/ with the right name, and
+    destruction of same on context exit.
+    """
+    lsd = landsat.landsatData(search=False)
+    with lsd.make_temp_proc_dir() as tempdir:
+        tempdir_existed = os.path.exists(tempdir)
+
+    # confirm was here, now it's gone, and had the right name
+    dir_prefix = lsd.Repository.path('stage') + '/proc'
+    assert tempdir_existed and not os.path.exists(tempdir) and tempdir.startswith(dir_prefix)

--- a/gips/test/int/t_utils.py
+++ b/gips/test/int/t_utils.py
@@ -1,0 +1,40 @@
+"""Integration tests for code in gips.utils."""
+
+import os
+
+import pytest
+
+from gips import utils
+
+
+class TestException(Exception):
+    """Custom exception to avoid masking any real one below."""
+
+
+test_content = "Have you ever retired a human by mistake?"
+
+@pytest.mark.parametrize('should_raise', (False, True))
+def t_make_temp_dir(should_raise):
+    """Test basic functionality of utils.make_temp_dir().
+
+    Confirm a file in the temp dir is usable and the dir is deleted even
+    if an exception is raised.
+    """
+    # make a temp dir and write to a file in it
+    did_raise = False
+    try:
+        with utils.make_temp_dir() as temp_dir:
+            fname = temp_dir + '/testfile'
+            with open(fname, 'a') as f:
+                f.write(test_content)
+            with open(fname, 'r') as f:
+                read_content = f.read()
+            if should_raise:
+                raise TestException('Like our owl?')
+    except TestException:
+        did_raise = True
+
+    # confirm writing worked, and the tempdir is destroyed on context exit, and an exception,
+    # if raised, was permitted to bubble up
+    assert (test_content == read_content and not os.path.exists(temp_dir)
+            and (did_raise if should_raise else True))

--- a/gips/test/sys/expected/prism.py
+++ b/gips/test/sys/expected/prism.py
@@ -67,6 +67,12 @@ t_process = {
         'prism/tiles/CONUS/19821201/PRISM_tmin_stable_4kmD1_19821201_bil.zip.index': -1015405459,
         'prism/tiles/CONUS/19821201/PRISM_ppt_stable_4kmD2_19821201_bil.zip.index': 1582653443,
     },
+    '_symlinks': {
+        # TODO do the rest of the symlinks as time allows
+        'prism/tiles/CONUS/19821201/CONUS_19821201_prism_ppt.tif':
+            'prism/tiles/CONUS/19821201/PRISM_ppt_stable_4kmD2_19821201_bil.zip'
+            '/PRISM_ppt_stable_4kmD2_19821201_bil.bil',
+    },
     'ignored': [
         'gips-inv-db.sqlite3',
     ],

--- a/gips/test/sys/expected/prism.py
+++ b/gips/test/sys/expected/prism.py
@@ -42,6 +42,7 @@ SENSORS\x1b[0m
 
 t_process = {
     'updated': {
+        'prism/stage': None,
         'prism/tiles/CONUS/19821201': None,
         'prism/tiles/CONUS/19821202': None,
         'prism/tiles/CONUS/19821203': None

--- a/gips/test/sys/t_prism.py
+++ b/gips/test/sys/t_prism.py
@@ -22,8 +22,8 @@ def setup_prism_data(pytestconfig):
     if not pytestconfig.getoption('setup_repo'):
         logger.debug("Skipping repo setup per lack of option.")
         return
-    logger.info("Downloading PRISM data . . .")
     cmd_str = 'gips_inventory ' + ' '.join(STD_ARGS) + ' --fetch'
+    logger.info("Downloading PRISM assets with " + cmd_str)
     outcome = envoy.run(cmd_str)
     logger.info("PRISM data download complete.")
     if outcome.status_code != 0:


### PR DESCRIPTION
This is the first two steps of #304, which is to write a method for `gips.data.core.Data` to let Data instances create tempdirs for making products.

Minor changes include various linewrapping, docstring, and other nonsemantic improvements.

Important changes:
* `gips.data.core.Data.make_temp_proc_dir`, which is a trivial wrapper around `gips.utils.make_temp_dir`, and integration tests for both.
* Use the tempdir method for prism processing.
* Just enough improvements to prism & the system test harness to make it functional enough to pass sys test t_process before I started changing things.  This took a lot longer than the changes to `prismData.process()` actually.  On the upside we have a pattern for testing symlink products now.

PS - I decided to leave the refactoring of repeated code at the beginning and end of the with-block until a future driver, since I'm not sure they're all going to act like prism yet.  Also I'm not sure if we prefer a single tempdir that's used throughout the process() call, or one for each product as I've done it.