### PR TITLE
#304 process decorator and some driver conversions

### DIFF
--- a/gips/data/core.py
+++ b/gips/data/core.py
@@ -989,3 +989,11 @@ class Data(object):
         This method should be called from within proc_temp_dir_manager.
         """
         return os.path.join(self._temp_proc_dir, os.path.basename(filename))
+
+    def product_filename(self, sensor, prod_type):
+        """Returns a standardized product file name."""
+        return '{}_{}_{}.tif'.format(self.basename, sensor, prod_type)
+
+    def temp_product_filename(self, sensor, prod_type):
+        """Generates a product filename within the managed temp dir."""
+        return self.generate_temp_path(self.product_filename(sensor, prod_type))

--- a/gips/data/merra/merra.py
+++ b/gips/data/merra/merra.py
@@ -469,15 +469,16 @@ class merraData(Data):
         imgout.SetAffine(np.array(self._geotransform))
 
 
+    @Data.proc_temp_dir_manager
     def process(self, *args, **kwargs):
-        """ create products """
+        """Produce requested products."""
         products = super(merraData, self).process(*args, **kwargs)
         if len(products) == 0:
             return
         bname = os.path.join(self.path, self.basename)
         sensor = "merra"
         for key, val in products.requested.items():
-            fout = "%s_%s_%s.tif" % (bname, sensor, key)
+            fout = self.temp_product_filename(sensor, key)
             meta = {}
             VERSION = "1.0"
             meta['VERSION'] = VERSION
@@ -634,4 +635,5 @@ class merraData(Data):
             """
 
             # add product to inventory
-            self.AddFile(sensor, key, fout)
+            archive_fp = self.archive_temp_path(fout)
+            self.AddFile(sensor, key, archive_fp)

--- a/gips/data/modis/modis.py
+++ b/gips/data/modis/modis.py
@@ -652,7 +652,6 @@ class modisData(Data):
                 imgout.SetGain(1.0)
                 imgout.SetBandName('Cloud Cover', 1)
                 imgout[0].Write(clouds)
-                VerboseOut('Completed writing %s' % fname)
 
             # SNOW/ICE COVER PRODUCT - FRACTIONAL masked with binary
             if val[0] == "fsnow":
@@ -897,8 +896,6 @@ class modisData(Data):
                 imgout[0].Write(coverout)
                 imgout[1].Write(fracout)
 
-                VerboseOut('Completed writing %s' % fname)
-
             ###################################################################
             # TEMPERATURE PRODUCT (DAILY)
             if val[0] == "temp":
@@ -1087,7 +1084,6 @@ class modisData(Data):
             # add product to inventory
             archive_fp = self.archive_temp_path(fname)
             self.AddFile(sensor, key, archive_fp)
-            utils.verbose_out('Completed writing ' + archive_fp)
             del imgout  # to cover for GDAL's internal problems
             utils.verbose_out(' -> {}: processed in {}'.format(
                 os.path.basename(fname), datetime.datetime.now() - start), level=1)

--- a/gips/data/modis/modis.py
+++ b/gips/data/modis/modis.py
@@ -413,11 +413,6 @@ class modisData(Data):
         }
     }
 
-    def generate_temp_path(self, sensor, prod_type):
-        """Syntactic sugar to avoid generating filenames again and again."""
-        filename = '{}_{}_{}.tif'.format(self.basename, sensor, prod_type)
-        return super(modisData, self).generate_temp_path(filename)
-
     @Data.proc_temp_dir_manager
     def process(self, *args, **kwargs):
         """Produce requested products."""
@@ -466,7 +461,7 @@ class modisData(Data):
 
             prod_type = val[0]
             sensor = self._products[prod_type]['sensor']
-            fname = self.generate_temp_path(sensor, prod_type) # moved to archive at bottom of loop
+            fname = self.temp_product_filename(sensor, prod_type) # moved to archive at end of loop
 
             if val[0] == "landcover":
                 os.symlink(allsds[0], fname)

--- a/gips/test/sys/expected/merra.py
+++ b/gips/test/sys/expected/merra.py
@@ -42,7 +42,10 @@ SENSORS\x1b[0m
 
 
 t_process = {
-    'updated': {'merra/tiles/h01v01/2015135': None},
+    'updated': {
+        'merra/stage': None,
+        'merra/tiles/h01v01/2015135': None,
+    },
     'created': {
         'merra/tiles/h01v01/2015135/h01v01_2015135_merra_patm.tif': -832862627,
         'merra/tiles/h01v01/2015135/h01v01_2015135_merra_prcp.tif': -1814551991,

--- a/gips/test/sys/expected/modis.py
+++ b/gips/test/sys/expected/modis.py
@@ -28,13 +28,14 @@ SENSORS\x1b[0m
 
 
 t_process = {
-    'updated': {'modis/tiles/h12v04/2012336': None,
-             'modis/tiles/h12v04/2012337': None,
-             'modis/tiles/h12v04/2012338': None},
+    'updated': {
+        'modis/stage': None,
+        'modis/tiles/h12v04/2012336': None,
+        'modis/tiles/h12v04/2012337': None,
+        'modis/tiles/h12v04/2012338': None,
+    },
     'created': {
-        # TODO Are these broken or what?  Each None is a broken symlink that seems to rely on weird
-        # gdal behavior (it uses the broken target of the symlink as a sort of data identifier?):
-        # See https://github.com/Applied-GeoSolutions/gips/issues/54
+        # Each None is a symlink; see prism for a way to test it more meaningfully.
         'modis/tiles/h12v04/2012336/h12v04_2012336_MCD_quality.tif': None,
         'modis/tiles/h12v04/2012337/h12v04_2012337_MCD_quality.tif': None,
         'modis/tiles/h12v04/2012337/h12v04_2012337_MOD_temp8td.tif': None,

--- a/gips/test/sys/t_merra.py
+++ b/gips/test/sys/t_merra.py
@@ -22,8 +22,8 @@ def setup_merra_data(pytestconfig):
     if not pytestconfig.getoption('setup_repo'):
         logger.debug("Skipping repo setup per lack of option.")
         return
-    logger.info("Downloading MERRA data . . .")
     cmd_str = 'gips_inventory ' + ' '.join(STD_ARGS) + ' --fetch'
+    logger.info("Downloading MERRA assets with " + cmd_str)
     outcome = envoy.run(cmd_str)
     logger.info("MERRA data download complete.")
     if outcome.status_code != 0:

--- a/gips/test/sys/t_modis.py
+++ b/gips/test/sys/t_modis.py
@@ -45,6 +45,8 @@ def t_inventory(setup_modis_data, repo_env, expected):
 
 def t_process(setup_modis_data, repo_env, expected):
     """Test gips_process on modis data."""
+    # TODO add landcover test; relevant invocation:
+    # gips_process modis -t h12v04 -p landcover -d 2012-01-01 -v6 --fetch
     actual = repo_env.run('gips_process', *STD_ARGS)
     assert expected == actual
 


### PR DESCRIPTION
Here's a decorator for making & destroying tempdirs & conversion of modis & merra to it.  sys test t_process passes.

Note the diff is a little strange around the modis landcover stanza; it thinks the if-statement got moved, when really things moved around it.

Doing this PR now, even though it's pretty short, so I can make sure the approach is acceptable before I rip through the rest of the drivers.

So github has breadcrumbs, this is for issue #304 even though it already says 304 all over the place.