### PR TITLE
convert sentinel2, daymet, and weld

### DIFF
--- a/gips/data/sentinel2/sentinel2.py
+++ b/gips/data/sentinel2/sentinel2.py
@@ -1004,7 +1004,6 @@ class sentinel2Data(Data):
         # process indices in two groups:  toa and surf
         indices = products.groups()['Index']
         toa_indices  = {k: v for (k, v) in indices.items() if 'toa' in v}
-        filename_prefix = os.path.join(self.path, self.basename + '_' + sensor + '_')
         self.process_indices('toa', sensor, toa_indices)
 
         surf_indices  = {k: v for (k, v) in indices.items() if 'toa' not in v}

--- a/gips/data/weld/weld.py
+++ b/gips/data/weld/weld.py
@@ -163,15 +163,17 @@ class weldData(Data):
         },
     }
 
+    @Data.proc_temp_dir_manager
     def process(self, *args, **kwargs):
-        """ Process all products """
+        """Process requested products."""
         products = super(weldData, self).process(*args, **kwargs)
         if len(products) == 0:
             return
-        bname = os.path.join(self.path, self.basename)
         for key, val in products.requested.items():
             start = datetime.datetime.now()
             sensor = 'WELD'
+            prod_type = val[0]
+            fname = self.temp_product_filename(sensor, prod_type) # moved to archive at end of loop
             # Check for asset availability
             assets = self._products[val[0]]['assets']
             missingassets = []
@@ -198,8 +200,6 @@ class weldData(Data):
             if val[0] == "ndsi":
                 VERSION = "1.0"
                 meta['VERSION'] = VERSION
-                sensor = "WELD"
-                fname = "%s_%s_%s" % (bname, sensor, key)
                 refl = gippy.GeoImage(allsds)
                 # band 2
                 grnimg = refl[1].Read()
@@ -234,8 +234,6 @@ class weldData(Data):
             if val[0] == "snow":
                 VERSION = "1.0"
                 meta['VERSION'] = VERSION
-                sensor = "WELD"
-                fname = "%s_%s_%s" % (bname, sensor, key)
                 refl = gippy.GeoImage(allsds)
                 # band 2
                 grnimg = refl[1].Read()
@@ -278,8 +276,6 @@ class weldData(Data):
             if val[0] == "ndvi":
                 VERSION = "1.0"
                 meta['VERSION'] = VERSION
-                sensor = "WELD"
-                fname = "%s_%s_%s" % (bname, sensor, key)
                 refl = gippy.GeoImage(allsds)
                 # band 3
                 redimg = refl[2].Read()
@@ -311,8 +307,6 @@ class weldData(Data):
             if val[0] == "brgt":
                 VERSION = "1.0"
                 meta['VERSION'] = VERSION
-                sensor = "WELD"
-                fname = "%s_%s_%s" % (bname, sensor, key)
                 refl = gippy.GeoImage(allsds)
                 # band 2
                 grnimg = refl[1].Read()
@@ -347,5 +341,6 @@ class weldData(Data):
             imgout.SetMeta(meta)
 
             # add product to inventory
-            self.AddFile(sensor, key, imgout.Filename())
+            archive_fp = self.archive_temp_path(fname)
+            self.AddFile(sensor, key, archive_fp)
             VerboseOut(' -> %s: processed in %s' % (os.path.basename(fname), datetime.datetime.now() - start), 1)

--- a/gips/test/sys/expected/sentinel2.py
+++ b/gips/test/sys/expected/sentinel2.py
@@ -56,6 +56,7 @@ _extraction_noise = [
 t_process = {
     'compare_stderr': False,
     'updated': {
+        'sentinel2/stage': None,
         'sentinel2/tiles/19TCH/2017010': None,
     },
     'created': {


### PR DESCRIPTION
For issue #304 convert three more drivers.  Sentinel-2 needed more refactoring than the others as it had its own way to handle broken product files, so that had to be removed to make it match the common way.