### PR TITLE
304 landsat temp dir usage (except acolite)

### DIFF
--- a/gips/data/core.py
+++ b/gips/data/core.py
@@ -992,7 +992,9 @@ class Data(object):
 
     def product_filename(self, sensor, prod_type):
         """Returns a standardized product file name."""
-        return '{}_{}_{}.tif'.format(self.basename, sensor, prod_type)
+        date_string = self.date.strftime(self.Repository._datedir)
+        # reminder: self.id is the tile ID string, eg 'h12v04' or '19TCH'
+        return '{}_{}_{}_{}.tif'.format(self.id, date_string, sensor, prod_type)
 
     def temp_product_filename(self, sensor, prod_type):
         """Generates a product filename within the managed temp dir."""


### PR DESCRIPTION
Biggest change outside tempdir usage is refactoring indices processing to a separate method, similarly to Sentinel-2.  Notice the `zip(...)` calls are removed; this is intentional as iterating through two different dicts in parallel seemed risky to me.

Given larger changes to landsat I didn't run the system tests, but all the code that got changed also got exercised I believe, by:

```
gips_process landsat -v6 -p bi lswi-toa ref-toa ref ndvi-toa bi-toa ndvi evi-toa -t 012030 -d 2015-352
GIPS_ORM=false gips_process landsat -v6 -p ndvi8sr -t 121061 -d 2014-233
```
Reason for `GIPS_ORM=false` is #315 