### PR TITLE
fix 305: hook prism fetch into archive process

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -107,8 +107,11 @@ def setup_data_repo():
     # set up data root if it isn't there already
     gcp = envoy.run("gips_config env")
     if gcp.status_code != 0:
-        raise RuntimeError("data root setup via `gips_config env` failed",
-                           gcp.std_out, gcp.std_err, gcp)
+        _log.error("data root setup via `gips_config env` failed; stdout:")
+        [_log.error(line) for line in gcp.std_out.split('\n')]
+        _log.error("data root setup via `gips_config env` failed; stderr:")
+        [_log.error(line) for line in gcp.std_err.split('\n')]
+        raise RuntimeError("data root setup via `gips_config env` failed")
     _log.debug("`gips_config env` succeeded; data repo (possibly) created")
 
 


### PR DESCRIPTION
Fixes #305 by letting the larger context do the DB insert for the asset.  Note that `test.sys.t_prism.t_inventory` passes now, which remedies the observed problem that lead to #305.