### PR TITLE
251 & 314 ORM & partial DH compatibility for two unusual drivers, daymet and CDL

### DIFF
--- a/gips/data/aod/aod.py
+++ b/gips/data/aod/aod.py
@@ -115,10 +115,8 @@ class aodAsset(Asset):
             5: 'Optical_Depth_Land_And_Ocean_Mean',
             6: 'Aerosol_Optical_Depth_Land_Ocean_Mean',
         }
-        self.products = {
-            'aod': (prefix + filename +
-                    '":mod08:{}'.format(sds[int(self.modis_collection)]))
-        }
+        self.products['aod'] = (
+                prefix + filename + '":mod08:{}'.format(sds[int(self.modis_collection)]))
 
     def datafiles(self):
         indexfile = self.filename + '.index'

--- a/gips/data/cdl/cdl.py
+++ b/gips/data/cdl/cdl.py
@@ -65,7 +65,13 @@ class cdlData(Data):
     version = '0.9.0'
     Asset = cdlAsset
     _products = {
-        _cdl: {'description': 'Crop Data Layer'}
+        _cdl: {
+            'description': 'Crop Data Layer',
+            'assets': [_cdl],
+            'bands': [{'name': _cdl, 'units': 'none'}],
+            # presently 'startdate' & 'latency' are permitted to be unspecified
+            # by DH gips.utils.get_data_variables
+        }
     }
 
     _legend = None

--- a/gips/data/cdl/cdl.py
+++ b/gips/data/cdl/cdl.py
@@ -22,11 +22,13 @@
 ################################################################################
 
 import os
-from datetime import datetime
+import datetime
 from csv import DictReader
 
 from gips.data.core import Repository, Asset, Data
 
+# make the compiler spell-check the one sensor, product, and asset type in the driver
+_cdl = 'cdl'
 
 class cdlRepository(Repository):
     name = 'CDL'
@@ -35,32 +37,26 @@ class cdlRepository(Repository):
     _defaultresolution = [30.0, 30.0]
     _tile_attribute = 'STATE_ABBR'
 
+
 class cdlAsset(Asset):
     Repository = cdlRepository
-    _sensors = {
-        'cdl': {'description': 'Crop Data Layer'}
-    }
+
+    _sensors = {_cdl: {'description': 'Crop Data Layer'}}
     _assets = {
-        '': {
-            'pattern': r'^CDL_.+?\.tif$'
+        _cdl: {
+            # CDL assets are named just like products: tile_date_sensor_asset-product.tif
+            'pattern': r'^(?P<tile>[A-Z]{2})_(?P<date>\d{4})_' + _cdl + '_' + _cdl + '\.tif$'
         }
     }
 
     def __init__(self, filename):
-        """ Inspect a CDL file """
+        """Use the given filename to set metadata."""
         super(cdlAsset, self).__init__(filename)
-        # TODO - get tile (state) so we can archive
-        bname = os.path.basename(filename)
-        try:
-            self.date = datetime.strptime(bname[4:8], self.Repository._datedir)
-        except:
-            self.date = datetime.strptime(bname[13:17], self.Repository._datedir)
-        self.products['cdl'] = filename
-        self.sensor = 'cdl'
-
-    @classmethod
-    def archive(cls, path=''):
-        raise Exception('Archive not supported')
+        self.tile, date_str = self.parse_asset_fp().group('tile', 'date')
+        self.date = datetime.datetime.strptime(date_str, self.Repository._datedir).date()
+        self.asset = _cdl
+        self.sensor = _cdl
+        self.products[_cdl] = filename # magically it is also a product
 
 
 class cdlData(Data):
@@ -69,18 +65,25 @@ class cdlData(Data):
     version = '0.9.0'
     Asset = cdlAsset
     _products = {
-        'cdl': {'description': 'Crop Data Layer'}
+        _cdl: {'description': 'Crop Data Layer'}
     }
 
-    _legend_file = os.path.join(cdlRepository.get_setting('repository'), 'CDL_Legend.csv')
-    _legend = [row['ClassName'].lower() for row in DictReader(open(_legend_file))]
+    _legend = None
+
+    @classmethod
+    def legend(cls):
+        """Open the legend file, keeping it memoized for future calls."""
+        if cls._legend is None:
+            legend_fp = os.path.join(cdlRepository.get_setting('repository'), 'CDL_Legend.csv')
+            cls._legend = [row['ClassName'].lower() for row in DictReader(open(legend_fp))]
+        return cls._legend
 
     @classmethod
     def get_code(cls, cropname):
-        ''' Retrieve CDL code for the given crop name (lower case) '''
-        return cls._legend.index(cropname)
+        """Retrieve CDL code for the given crop name (lower case)."""
+        return cls.legend().index(cropname)
 
     @classmethod
     def get_cropname(cls, code):
-        '''Retrieve name associated with given crop code'''
-        return cls._legend[code]
+        """Retrieve name associated with given crop code."""
+        return cls.legend()[code]

--- a/gips/data/core.py
+++ b/gips/data/core.py
@@ -27,7 +27,6 @@ import errno
 from osgeo import gdal, ogr
 from datetime import datetime
 import glob
-import re
 from itertools import groupby
 from shapely.wkt import loads
 import tarfile
@@ -647,7 +646,6 @@ class Data(object):
         self.assets = {}      # dict of <asset type string>: <Asset instance>
         self.filenames = {}   # dict of (sensor, product): product filename
         self.sensors = {}     # dict of asset/product: sensor
-        # self.basename       # self.path + part of a product filename; used as a prefix; set below
         if tile is not None and date is not None:
             self.path = self.Repository.data_path(tile, date)
             self.basename = self.id + '_' + self.date.strftime(self.Repository._datedir)

--- a/gips/data/core.py
+++ b/gips/data/core.py
@@ -27,6 +27,7 @@ import errno
 from osgeo import gdal, ogr
 from datetime import datetime
 import glob
+import re
 from itertools import groupby
 from shapely.wkt import loads
 import tarfile
@@ -220,6 +221,19 @@ class Asset(object):
     ##########################################################################
     # Child classes should not generally have to override anything below here
     ##########################################################################
+    def parse_asset_fp(self):
+        """Parse self.filename using the class's asset patterns.
+
+        On the first successful match, the re lib match object is
+        returned. Raises ValueError on failure to parse.
+        """
+        asset_bn = os.path.basename(self.filename)
+        for av in self._assets.values():
+            match = re.match(av['pattern'], asset_bn)
+            if match is not None:
+                return match
+        raise ValueError("Unparseable asset file name:  " + self.filename)
+
     def datafiles(self):
         """Get list of readable datafiles from asset.
 

--- a/gips/data/daymet/daymet.py
+++ b/gips/data/daymet/daymet.py
@@ -138,20 +138,6 @@ class daymetAsset(Asset):
 
     _defaultresolution = (1000., 1000.,)
 
-    def parse_asset_fp(self):
-        """Parse self.filename using the class's asset patterns.
-
-        On the first successful match, the re lib match object is
-        returned. Raises ValueError on failure to parse.
-        """
-        # this method may be useful in core.Asset
-        asset_bn = os.path.basename(self.filename)
-        for av in self._assets.values():
-            match = re.match(av['pattern'], asset_bn)
-            if match is not None:
-                return match
-        raise ValueError("Unparseable asset file name:  " + self.filename)
-
     def __init__(self, filename):
         """Uses regexes above to parse filename & save metadata."""
         super(daymetAsset, self).__init__(filename)

--- a/gips/data/daymet/daymet.py
+++ b/gips/data/daymet/daymet.py
@@ -207,22 +207,37 @@ class daymetData(Data):
     _products = {
         'tmin': {
             'description': 'Daily minimum air temperature (C)',
-            'assets': ['tmin']
+            'assets': ['tmin'],
+            'bands': [{'name': 'tmin', 'units': 'degree Celcius'}],
+            'startdate': Asset._startdate,
+            'latency': Asset._latency,
         },
         'tmax': {
             'description': 'Daily maximum air temperature (C)',
-            'assets': ['tmax']
+            'assets': ['tmax'],
+            'bands': [{'name': 'tmax', 'units': 'degree Celcius'}],
+            'startdate': Asset._startdate,
+            'latency': Asset._latency,
         },
         'prcp': {
             'description': 'Daily precipitation (mm)',
-            'assets': ['prcp']
+            'assets': ['prcp'],
+            'bands': [{'name': 'prcp', 'units': 'mm'}],
+            'startdate': Asset._startdate,
+            'latency': Asset._latency,
         },
         'srad': {
             'description': 'Daily solar radiation (W m-2)',
-            'assets': ['srad']
+            'assets': ['srad'],
+            'bands': [{'name': 'srad', 'units': 'W/m^2'}],
+            'startdate': Asset._startdate,
+            'latency': Asset._latency,
         },
         'vp': {
             'description': 'Daily vapor pressure (Pa)',
-            'assets': ['vp']
+            'assets': ['vp'],
+            'bands': [{'name': 'srad', 'units': 'Pa'}],
+            'startdate': Asset._startdate,
+            'latency': Asset._latency,
         },
     }

--- a/gips/data/daymet/daymet.py
+++ b/gips/data/daymet/daymet.py
@@ -21,10 +21,19 @@
 #   along with this program. If not, see <http://www.gnu.org/licenses/>
 ################################################################################
 
+"""Daymet driver module; see https://daymet.ornl.gov/
+
+Daymet is an unusual GIPS driver in that its assets are also its
+products. During fetch, files are constructed out of data downloaded in
+non-file format (via opendap). These files are then available as both
+assets and products simultaneously.
+"""
+
 import os
 import datetime
 import time
 import numpy as np
+import re
 
 from pydap.client import open_url
 
@@ -32,9 +41,6 @@ import gippy
 from gips.data.core import Repository, Asset, Data
 from gips.utils import VerboseOut, basename
 from gips import utils
-
-
-from pdb import set_trace
 
 requirements =['pydap']
 
@@ -73,14 +79,21 @@ class daymetAsset(Asset):
         }
     }
 
+    _sensor = 'daymet' # only one in the driver
+
     _latency = 0
     _startdate = datetime.date(1980, 1, 1)
     _url = "https://thredds.daac.ornl.gov/thredds/dodsC/ornldaac/1328/tiles/%d/%s_%d"
 
+    # daymet assets are named just like products: tile_date_sensor_asset/product.tif
+    _asset_template = '{}_{}_{}_{}.tif' # for generating filenames
+    # for validating and parsing filenames - doubling of {} is due to format() -----vv
+    _asset_re = r'^(?P<tile>\d{{5}})_(?P<date>\d{{7}})_' + _sensor + r'_(?P<ap_type>{})\.tif$'
+
     _assets = {
         'tmin': {
             'description': 'Daily minimum air temperature (C)',
-            'pattern': r'^daymet_tmin_.+?_.{7}\.tif$',
+            'pattern': _asset_re.format('tmin'),
             'source': 'tmin.nc',
             'url': _url,
             'startdate': _startdate,
@@ -88,7 +101,7 @@ class daymetAsset(Asset):
         },
         'tmax': {
             'description': 'Daily maximum air temperature (C)',
-            'pattern': r'^daymet_tmax_.+?_.{7}\.tif$',
+            'pattern': _asset_re.format('tmax'),
             'source': 'tmax.nc',
             'url': _url,
             'startdate': _startdate,
@@ -96,7 +109,7 @@ class daymetAsset(Asset):
         },
         'prcp': {
             'description': 'Daily precipitation (mm)',
-            'pattern': r'^daymet_prcp_.+?_.{7}\.tif$',
+            'pattern': _asset_re.format('prcp'),
             'source': 'prcp.nc',
             'url': _url,
             'startdate': _startdate,
@@ -104,7 +117,7 @@ class daymetAsset(Asset):
         },
         'srad': {
             'description': 'Daily solar radiation (W m-2)',
-            'pattern': r'^daymet_srad_.+?_.{7}\.tif$',
+            'pattern': _asset_re.format('srad'),
             'source': 'srad.nc',
             'url': _url,
             'startdate': _startdate,
@@ -112,7 +125,7 @@ class daymetAsset(Asset):
         },
         'vp': {
             'description': 'Daily vapor pressure (Pa)',
-            'pattern': r'^daymet_vp_.+?_.{7}\.tif$',
+            'pattern': _asset_re.format('vp'),
             'source': 'vp.nc',
             'url': _url,
             'startdate': _startdate,
@@ -122,14 +135,28 @@ class daymetAsset(Asset):
 
     _defaultresolution = (1000., 1000.,)
 
+    def parse_asset_fp(self):
+        """Parse self.filename using the class's asset patterns.
+
+        On the first successful match, the re lib match object is
+        returned. Raises ValueError on failure to parse.
+        """
+        # this method may be useful in core.Asset
+        asset_bn = os.path.basename(self.filename)
+        for av in self._assets.values():
+            match = re.match(av['pattern'], asset_bn)
+            if match is not None:
+                return match
+        raise ValueError("Unparseable asset file name:  " + self.filename)
+
     def __init__(self, filename):
-        """ Inspect a single file and get some metadata """
+        """Uses regexes above to parse filename & save metadata."""
         super(daymetAsset, self).__init__(filename)
-        parts = basename(filename).split('_')
-        self.sensor = 'daymet'
-        self.asset = parts[1]
-        self.tile = parts[2]
-        self.date = datetime.datetime.strptime(parts[3], '%Y%j').date()
+        self.tile, date_str, self.asset = (
+            self.parse_asset_fp().group('tile', 'date', 'ap_type'))
+        self.date = datetime.datetime.strptime(date_str, '%Y%j').date()
+        self.sensor = self._sensor
+        # how daymet products load magically
         self.products[self.asset] = filename
 
 
@@ -139,7 +166,7 @@ class daymetAsset(Asset):
         url = cls._assets[asset].get('url', '') % (date.year, tile, date.year)
         source = cls._assets[asset]['source'] 
         loc = "%s/%s" % (url, source)
-        print loc
+        utils.verbose_out(loc)
         dataset = open_url(loc)
         x0 = dataset['x'].data[0] - 500.0
         y0 = dataset['y'].data[0] + 500.0
@@ -155,7 +182,8 @@ class daymetAsset(Asset):
                float(y0), 0.0, -cls._defaultresolution[1]]
         geo = np.array(geo).astype('double')
         dtype = create_datatype(data.dtype)
-        filename = "daymet_%s_%s_%4d%s.tif" % (asset, tile, date.year, sday)
+        date_str = date.strftime(cls.Repository._datedir)
+        filename = cls._asset_template.format(tile, date_str, cls._sensor, asset)
         stage_dir = cls.Repository.path('stage')
         with utils.make_temp_dir(prefix='fetch', dir=stage_dir) as temp_dir:
             temp_fp = os.path.join(temp_dir, filename)
@@ -167,6 +195,7 @@ class daymetAsset(Asset):
             imgout.SetAffine(geo)
             imgout[0].Write(data)
             os.rename(temp_fp, stage_fp)
+            return [stage_fp]
 
 
 class daymetData(Data):

--- a/gips/inventory/__init__.py
+++ b/gips/inventory/__init__.py
@@ -236,10 +236,16 @@ class DataInventory(Inventory):
 
             if orm.use_orm():
                 # save metadata about the fetched assets in the database
+                driver = dataclass.name.lower()
                 for a in archived_assets:
                     dbinv.update_or_add_asset(
                             asset=a.asset, sensor=a.sensor, tile=a.tile, date=a.date,
-                            name=a.archived_filename, driver=dataclass.name.lower())
+                            name=a.archived_filename, driver=driver)
+                    # if the new asset comes with any "free" products, save that info:
+                    for (prod_type, fp) in a.products.items():
+                        dbinv.update_or_add_product(
+                                product=prod_type, sensor=a.sensor, tile=a.tile, date=a.date,
+                                name=fp, driver=driver)
 
         # Build up the inventory:  One Tiles object per date.  Each contains one Data object.  Each
         # of those contain one or more Asset objects.
@@ -272,7 +278,7 @@ class DataInventory(Inventory):
             for a in dbinv.asset_search(**search_criteria).order_by('date', 'tile'):
                 add_to_collection(a.date, a.tile, 'a', str(a.name))
 
-            # the collection is now copmlete so use it to populate the GIPS object hierarchy
+            # the collection is now complete so use it to populate the GIPS object hierarchy
             for k, v in collection.items():
                 (date, tile) = k
                 # find or else make a Tiles object

--- a/gips/inventory/dbinv/api.py
+++ b/gips/inventory/dbinv/api.py
@@ -130,11 +130,6 @@ def rectify_products(data_class):
     starting_keys = set(mpo.filter(driver=driver).values_list('id', flat=True))
 
     def rectify_product(full_fn):
-        # TODO if data_class.name == 'Daymet':
-        #   # Daymet assets & products are the same, so use Asset parsing to make Products
-        #   daymet_asset = data_class.Asset(full_fn)
-        #   # extract metadata here
-        #   # save deets as usual
         bfn_parts = basename(full_fn).split('_')
         if not len(bfn_parts) == 4:
             _match_failure_report(full_fn,

--- a/gips/inventory/orm/__init__.py
+++ b/gips/inventory/orm/__init__.py
@@ -34,7 +34,7 @@ def setup():
     if setup_complete:
         return
     if use_orm():
-        busted_drivers = ('sar', 'sarannual', 'daymet', 'cdl')
+        busted_drivers = ('sar', 'sarannual', 'cdl')
 
         if driver_for_dbinv_feature_toggle in busted_drivers:
             msg = ("Inventory database does not support '{}'.  "

--- a/gips/inventory/orm/__init__.py
+++ b/gips/inventory/orm/__init__.py
@@ -34,7 +34,7 @@ def setup():
     if setup_complete:
         return
     if use_orm():
-        busted_drivers = ('sar', 'sarannual', 'cdl')
+        busted_drivers = ('sar', 'sarannual')
 
         if driver_for_dbinv_feature_toggle in busted_drivers:
             msg = ("Inventory database does not support '{}'.  "

--- a/gips/test/unit/t_daymet.py
+++ b/gips/test/unit/t_daymet.py
@@ -1,0 +1,40 @@
+import datetime
+
+import pytest
+
+from ...data.daymet import daymet
+
+# approach here is cribbed from unit/t_landsat.py
+
+_2015002 = datetime.date(2015, 1, 2)
+_afps = { # asset full paths
+    'tmin': '/repo/daymet/tiles/11935/2015002/11935_2015002_daymet_tmin.tif',
+    'tmax': '/repo/daymet/tiles/11935/2015002/11935_2015002_daymet_tmax.tif',
+    'prcp': '/repo/daymet/tiles/11935/2015002/11935_2015002_daymet_prcp.tif',
+    'srad': '/repo/daymet/tiles/11935/2015002/11935_2015002_daymet_srad.tif',
+    'vp':   '/repo/daymet/tiles/11935/2015002/11935_2015002_daymet_vp.tif',
+}
+
+# inputs and outputs for the base case - one for each asset/product type
+asset_constructor_base_case_params = [
+    (asset_fp, (asset_fp, ap_type, '11935', _2015002, 'daymet', {ap_type: asset_fp}))
+    for ap_type, asset_fp in _afps.items()
+]
+
+@pytest.mark.parametrize("fn, expected", asset_constructor_base_case_params)
+def t_daymetAsset_constructor_base_case(fn, expected):
+    """Confirm well-behaved files go in correctly."""
+    a = daymet.daymetAsset(fn)
+    assert expected == (a.filename, a.asset, a.tile, a.date, a.sensor, a.products)
+
+@pytest.mark.parametrize("fn, message", (
+    ('/repo/daymet/tiles/11935/2015002/11935_2015002_daymet_xxx.tif', 'bad asset/product type'),
+    ('/repo/daymet/tiles/11935/2015002/11935_daymet_tmin.tif', 'missing a token'),
+    ('/repo/daymet/tiles/11935/2015002/11935_2015002_daymet_tmin.tif.index', 'trailing characters'),
+    ('/repo/daymet/tiles/11935/2015002/foo_11935_2015002_daymet_tmin.tif', 'leading characters'),
+    ('/repo/daymet/tiles/11935/2015002/11935_2015002_daymet_tmin_x.tif', 'extra token'),
+))
+def t_daymetAsset_constructor_error_case(fn, message):
+    """Confirm malformed files cause exceptions."""
+    with pytest.raises(ValueError, message=message):
+        a = daymet.daymetAsset(fn)


### PR DESCRIPTION
Fixes for #251 & #314; note this replaces PR #314; also the branch is based on latest dev, not the commit the previous PR was based on.  As usual, there's minor refactoring & stale/redundant comment cleanup here and there, and these bigger changes:

## Changes to core gips

Sometimes assets have products built in to them (self.products). After fetch, add those products to the ORM.  New method `core.Asset.parse_asset_fp` that provides a common way to parse asset filenames.  `busted_drivers` loses daymet & CDL entries.

## Changes to drivers

AOD got refactoring to use an existing dict instead of overwriting it; this makes debugging easier.

CDL & daymet both got their asset/product files renamed to match standard gips products.  This is to make various things work more smoothly, most notably product rectification.  Both got their assets looped in to use regexes in a recently-emerging general pattern.  Also both got metadata for their products suitable for eventual inclusion in the datahandler; see `gips.utils.get_data_variables()` on the datahandler branch.

CDL got its CSV reading refactored into a method so CDL can't break all of gips when the file is missing.  Now that `archive` seems to work, remove the blocking method.

Daymet fetch was significantly refactored for metadata insertion & leveraging file naming code.  Also its return value now follows convention.  Daymet's file name regexes got unit tests; I figure regexes are dense and fiddly enough semanticaly that it was worth spending the time, given troubles we've had recently with regexes in this area.

## possible risks

AOD also uses `Asset.products = {...}`.  After this PR, the filename-but-not that it saves in there will be added to the dbinv, but this doesn't seem to break anything as Data.ParseAndAddFiles just rejects it as a bad filename, and it gets into the aodData instance anyway during add_asset() to pick up the sneaky value from `Asset.products`. So . . . do I need to do something about that or leave it out? I couldn't decide so I issued the PR as-is.

Note I can easily turn off specific drivers by looking for a special attrib in the driver's data class at ORM insertion time (in DataInventory just after fetch).  I can also make it the driver's responsibility to do the ORM insertion, write a default method appropriately for most drivers, then null it out for AOD.
