### PR TITLE
131 335 refactor ftp & aod query/fetch

### DIFF
--- a/gips/data/core.py
+++ b/gips/data/core.py
@@ -412,6 +412,17 @@ class Asset(object):
         raise NotImplementedError("Fetch not supported for this data source")
 
     @classmethod
+    def ftp_connect(cls, working_directory):
+        """Connect to an FTP server and chdir according to the args.
+
+        Returns the ftplib connection object."""
+        conn = ftplib.FTP(cls._host)
+        conn.login('anonymous', settings().EMAIL)
+        conn.set_pasv(True)
+        conn.cwd(working_directory)
+        return conn
+
+    @classmethod
     def fetch_ftp(cls, asset, tile, date):
         """ Fetch via FTP """
         url = cls._assets[asset].get('url', '')

--- a/gips/data/prism/prism.py
+++ b/gips/data/prism/prism.py
@@ -92,18 +92,11 @@ class prismAsset(Asset):
         'provisional': 1,
     }
 
-
     @classmethod
     def ftp_connect(cls, asset, date):
-        """Connect to the PRISM servers and chdir according to the args.
-
-        Returns the ftplib connection object."""
-        conn = ftplib.FTP(cls._host)
-        conn.login('anonymous', settings().EMAIL)
-        conn.set_pasv(True)
-        conn.cwd(os.path.join(cls._assets[asset]['path'], date.strftime('%Y')))
-        return conn
-
+        """As super, but make the working dir out of (asset, date)."""
+        wd = os.path.join(cls._assets[asset]['path'], date.strftime('%Y'))
+        return super(prismAsset, cls).ftp_connect(wd)
 
     @classmethod
     def query_provider(cls, asset, tile, date, conn=None):


### PR DESCRIPTION
Fixes, I think, both #131 & #335.  Basically I mimicked prism, and refactored prism a little into common code besides.  Implemented query_provider for aod, and have aod use that for its fetch.  As such now there are no users of `Asset.fetch_ftp`, I don't think.  Deleting that method can be added to this PR if desired.