### PR TITLE
adding VARI to landsat

### DIFF
--- a/gips/data/landsat/landsat.py
+++ b/gips/data/landsat/landsat.py
@@ -340,7 +340,8 @@ class landsatData(Data):
 
     # Group products belong to ('Standard' if not specified)
     _productgroups = {
-        'Index': ['bi', 'evi', 'lswi', 'msavi2', 'ndsi', 'ndvi', 'ndwi', 'satvi'],
+        'Index': ['bi', 'evi', 'lswi', 'msavi2', 'ndsi', 'ndvi', 'ndwi',
+                  'satvi', 'vari'],
         'Tillage': ['ndti', 'crc', 'sti', 'isti'],
         'LC8SR': ['ndvi8sr'],
         'ACOLITE': [
@@ -492,6 +493,12 @@ class landsatData(Data):
             'description': 'Soil-Adjusted Total Vegetation Index',
             'arguments': [__toastring],
             'bands': ['satvi'],
+        },
+        'vari': {
+            'assets': ['DN', 'C1'],
+            'description': 'Visible Atmospherically Resistant Index',
+            'arguments': [__toastring],
+            'bands': ['vari'],
         },
         #'Tillage Indices': {
         'ndti': {

--- a/gips/test/sys/expected/landsat.py
+++ b/gips/test/sys/expected/landsat.py
@@ -54,11 +54,12 @@ Standard Products
                  X: erosion kernel diameter in pixels (default: 5)
                  Y: dilation kernel diameter in pixels (default: 10)
                  Z: cloud height in meters (default: 4000)
-   bqa         LC8 band quality                        
+   bqa         The quality band extracted into separate layers.
    bqashadow   LC8 QA + Shadow Smear                   
                  X: erosion kernel diameter in pixels (default: 5)
                  Y: dilation kernel diameter in pixels (default: 10)
                  Z: cloud height in meters (default: 4000)
+   cloudmask   Cloud mask product based on cloud bits of the quality band
    dn          Raw digital numbers                     
    fmask       Fmask cloud cover                       
    landmask    Land mask from LC8SR                    

--- a/gips/test/sys/expected/landsat.py
+++ b/gips/test/sys/expected/landsat.py
@@ -24,6 +24,8 @@ Index Products
                  toa: use top of the atmosphere reflectance
    satvi       Soil-Adjusted Total Vegetation Index    
                  toa: use top of the atmosphere reflectance
+   vari        Visible Atmospherically Resistant Index 
+                 toa: use top of the atmosphere reflectance
 \x1b[1m
 LC8SR Products
 \x1b[0m   ndvi8sr     Normalized Difference Vegetation from LC8SR


### PR DESCRIPTION
quick addition of existing gippy.algorithms.Indices product.

Only change to current tests is that it shows up in `gips_info` output.