### PR TITLE
unbreak rios install & landsat's use of usgs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -38,7 +38,7 @@ pip install 'https://github.com/Applied-GeoSolutions/gippy/tarball/v0.3.x#egg=gi
 
 echo === install GIPS itself ===
 # TODO --process-dependency-links is deprecated
-pip install -e .
+pip install -e . --process-dependency-links
 
 # help user with configuration
 echo "Install complete.  GIPS configuration:"

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         'pysolar==0.6',
         'rios==1.4.3',
         'python-fmask==0.4.5',
+        'usgs', # 0.2.1 known to work
     ],
     dependency_links=[
         'https://bitbucket.org/chchrsc/rios/downloads/rios-1.4.3.zip#egg=rios-1.4.3',


### PR DESCRIPTION
Tested with making a fresh venv, then activating it, then:

```
(.venv) tolsonlt:~/src/also-gips$ fmask_sentinel2makeAnglesImage.py # <-- imports rios
usage: fmask_sentinel2makeAnglesImage.py [-h] [-i INFILE] [-o OUTFILE]

optional arguments:
  -h, --help            show this help message and exit
  -i INFILE, --infile INFILE
                        Input sentinel-2 tile metafile
  -o OUTFILE, --outfile OUTFILE
                        Output angles image file
```

For usgs I did `python -c 'import gips.data.landsat.landsat'`; before, ImportError and heartbreak :broken_heart: , after, joy and rainbows. :rainbow: 