### PR TITLE
392 acolite for s2

### DIFF
--- a/gips/atmosphere.py
+++ b/gips/atmosphere.py
@@ -39,6 +39,7 @@ import shutil
 import tarfile
 import re
 import glob
+import copy
 
 import numpy
 import netCDF4
@@ -382,6 +383,94 @@ class MODTRAN():
     fout.close()
     """
 
+
+_aco_prod_templs = {
+    'rhow': {
+        'description': 'Water-Leaving Radiance-Reflectance',
+        'acolite-product': 'rhow_vnir',
+        'acolite-key': 'RHOW',
+        'gain': 0.0001,
+        'offset': 0.,
+        'dtype': 'int16',
+        'toa': True,
+        'bands': [],
+    },
+    # Not sure what the issue is with this product, but it doesn't seem to
+    # work as expected (multiband vis+nir product)
+    # 'rhoam': {
+    #     'description': 'Multi-Scattering Aerosol Reflectance',
+    #     'acolite-product': 'rhoam_vnir',
+    #     'acolite-key': 'RHOAM',
+    #     'dtype': 'int16',
+    #     'toa': True,
+    # },
+    'oc2chl': {
+        'description': 'Blue-Green Ratio Chlorophyll Algorithm using bands 483 & 561',
+        'acolite-product': 'CHL_OC2',
+        'acolite-key': 'CHL_OC2',
+        'gain': 0.0125,
+        'offset': 250.,
+        'dtype': 'int16',
+        'toa': True,
+        'bands': [],
+    },
+    'oc3chl': {
+        'description': 'Blue-Green Ratio Chlorophyll Algorithm using bands 443, 483, & 561',
+        'acolite-product': 'CHL_OC3',
+        'acolite-key': 'CHL_OC3',
+        'gain': 0.0125,
+        'offset': 250.,
+        'dtype': 'int16',
+        'toa': True,
+        'bands': [],
+    },
+    'fai': {
+        'description': 'Floating Algae Index',
+        'acolite-product': 'FAI',
+        'acolite-key': 'FAI',
+        'dtype': 'float32',
+        'toa': True,
+        'bands': [],
+    },
+    'acoflags': {
+        'description': '0 = water 1 = no data 2 = land',
+        'acolite-product': 'FLAGS',
+        'acolite-key': 'FLAGS',
+        'dtype': 'uint8',
+        'toa': True,
+        'bands': [],
+    },
+    'spm655': {
+        'description': 'Suspended Sediment Concentration 655nm',
+        'acolite-product': 'SPM_NECHAD_655',
+        'acolite-key': 'SPM_NECHAD_655',
+        'offset': 50.,
+        'gain': 0.005,
+        'dtype': 'int16',
+        'toa': True,
+        'bands': [],
+    },
+    'turbidity': {
+        'description': 'Blended Turbidity',
+        'acolite-product': 'T_DOGLIOTTI',
+        'acolite-key': 'T_DOGLIOTTI',
+        'offset': 50.,
+        'gain': 0.005,
+        'dtype': 'int16',
+        'toa': True,
+        'bands': [],
+    },
+}
+
+def add_acolite_product_dicts(_products, *assets):
+    """Add the acolite product dicts to the given Data._products.
+
+    'assets' is different for each driver, so pass it in."""
+    # make copies just in case anything is modified
+    aco_prods = copy.deepcopy(_aco_prod_templs)
+    for inner in aco_prods.values():
+        inner['assets'] = list(assets) # just in case, don't re-use the list
+    _products.update(aco_prods)
 
 def process_acolite(asset, aco_proc_dir, products):
     """Generate acolite products from the given asset.

--- a/gips/atmosphere.py
+++ b/gips/atmosphere.py
@@ -49,6 +49,7 @@ from gips.utils import List2File, verbose_out
 from gips import utils
 from gips.data.merra import merraData
 from gips.data.aod import aodData
+from gips.data.core import Data
 from gips.inventory import orm
 
 # since Py6S pulls in matplotlib, we need to shut down all that gui business
@@ -383,7 +384,6 @@ class MODTRAN():
     fout.close()
     """
 
-
 _aco_prod_templs = {
     'rhow': {
         'description': 'Water-Leaving Radiance-Reflectance',
@@ -393,7 +393,9 @@ _aco_prod_templs = {
         'offset': 0.,
         'dtype': 'int16',
         'toa': True,
-        'bands': [],
+        'bands': [{'name': bn, 'units': Data._unitless} for bn in (
+                    '444nm', '497nm', '560nm', '664nm', '704nm',
+                    '740nm', '782nm', '835nm', '865nm', '1614nm', '2202nm')]
     },
     # Not sure what the issue is with this product, but it doesn't seem to
     # work as expected (multiband vis+nir product)
@@ -412,7 +414,7 @@ _aco_prod_templs = {
         'offset': 250.,
         'dtype': 'int16',
         'toa': True,
-        'bands': [],
+        'bands': [{'name': 'oc2chl', 'units': Data._unitless}],
     },
     'oc3chl': {
         'description': 'Blue-Green Ratio Chlorophyll Algorithm using bands 443, 483, & 561',
@@ -422,7 +424,7 @@ _aco_prod_templs = {
         'offset': 250.,
         'dtype': 'int16',
         'toa': True,
-        'bands': [],
+        'bands': [{'name': 'oc3chl', 'units': Data._unitless}],
     },
     'fai': {
         'description': 'Floating Algae Index',
@@ -430,7 +432,7 @@ _aco_prod_templs = {
         'acolite-key': 'FAI',
         'dtype': 'float32',
         'toa': True,
-        'bands': [],
+        'bands': [{'name': 'fai', 'units': Data._unitless}],
     },
     'acoflags': {
         'description': '0 = water 1 = no data 2 = land',
@@ -438,7 +440,7 @@ _aco_prod_templs = {
         'acolite-key': 'FLAGS',
         'dtype': 'uint8',
         'toa': True,
-        'bands': [],
+        'bands': [{'name': 'acoflags', 'units': Data._unitless}],
     },
     'spm655': {
         'description': 'Suspended Sediment Concentration 655nm',
@@ -448,7 +450,7 @@ _aco_prod_templs = {
         'gain': 0.005,
         'dtype': 'int16',
         'toa': True,
-        'bands': [],
+        'bands': [{'name': 'spm655', 'units': 'unknown'}],
     },
     'turbidity': {
         'description': 'Blended Turbidity',
@@ -458,7 +460,7 @@ _aco_prod_templs = {
         'gain': 0.005,
         'dtype': 'int16',
         'toa': True,
-        'bands': [],
+        'bands': [{'name': 'turbidity', 'units': Data._unitless}],
     },
 }
 

--- a/gips/atmosphere.py
+++ b/gips/atmosphere.py
@@ -613,13 +613,12 @@ def process_acolite(asset, aco_proc_dir, products,
         imgout = gippy.GeoImage(ofname, tmp, dtype, len(bands))
         # # TODO: add units to products dictionary and use here.
         # imgout.SetUnits(products[key]['units'])
-        pmeta = dict()
-        pmeta.update(imeta)
         pmeta = {
             mdi: products[key][mdi]
             for mdi in ['acolite-key', 'description']
             }
         pmeta['source_asset'] = os.path.basename(asset.filename)
+        pmeta.update(imeta)
         imgout.SetMeta(pmeta)
         for i, b in enumerate(bands):
             imgout.SetBandName(str(b), i + 1)

--- a/gips/atmosphere.py
+++ b/gips/atmosphere.py
@@ -476,7 +476,7 @@ def add_acolite_product_dicts(_products, *assets):
 
 def process_acolite(asset, aco_proc_dir, products,
                     model_layer_re=r'.*\.((jp2)|(tif)|(TIF))$',
-                    extracted_asset_glob='.'):
+                    extracted_asset_glob=''):
     """Generate acolite products from the given asset.
 
     Args:

--- a/gips/data/landsat/landsat.py
+++ b/gips/data/landsat/landsat.py
@@ -1047,7 +1047,7 @@ class landsatData(Data):
                         amd[p].update(self._products[p])
                         amd[p].pop('assets')
                     prodout = gips.atmosphere.process_acolite(
-                            self.assets[asset], asset, aco_proc_dir, amd)
+                            self.assets[asset], aco_proc_dir, amd)
                     endtime = datetime.now()
                     for k, fn in prodout.items():
                         self.AddFile(sensor, k, fn)

--- a/gips/data/landsat/landsat.py
+++ b/gips/data/landsat/landsat.py
@@ -566,91 +566,9 @@ class landsatData(Data):
             'description': 'Land mask from LC8SR',
             'bands': ['Land mask'],
         },
-        # ACOLITE products
-        'rhow': {
-            'assets': ['DN', 'C1'],
-            'description': 'Water-Leaving Radiance-Reflectance',
-            'acolite-product': 'rhow_vnir',
-            'acolite-key': 'RHOW',
-            'gain': 0.0001,
-            'offset': 0.,
-            'dtype': 'int16',
-            'toa': True,
-            'bands': [],
-        },
-        # Not sure what the issue is with this product, but it doesn't seem to
-        # work as expected (multiband vis+nir product)
-        # 'rhoam': {
-        #     'assets': ['DN'],
-        #     'description': 'Multi-Scattering Aerosol Reflectance',
-        #     'acolite-product': 'rhoam_vnir',
-        #     'acolite-key': 'RHOAM',
-        #     'dtype': 'int16',
-        #     'toa': True,
-        # },
-        'oc2chl': {
-            'assets': ['DN', 'C1'],
-            'description': 'Blue-Green Ratio Chlorophyll Algorithm using bands 483 & 561',
-            'acolite-product': 'CHL_OC2',
-            'acolite-key': 'CHL_OC2',
-            'gain': 0.0125,
-            'offset': 250.,
-            'dtype': 'int16',
-            'toa': True,
-            'bands': [],
-        },
-        'oc3chl': {
-            'assets': ['DN', 'C1'],
-            'description': 'Blue-Green Ratio Chlorophyll Algorithm using bands 443, 483, & 561',
-            'acolite-product': 'CHL_OC3',
-            'acolite-key': 'CHL_OC3',
-            'gain': 0.0125,
-            'offset': 250.,
-            'dtype': 'int16',
-            'toa': True,
-            'bands': [],
-        },
-        'fai': {
-            'assets': ['DN', 'C1'],
-            'description': 'Floating Algae Index',
-            'acolite-product': 'FAI',
-            'acolite-key': 'FAI',
-            'dtype': 'float32',
-            'toa': True,
-            'bands': [],
-        },
-        'acoflags': {
-            'assets': ['DN', 'C1'],
-            'description': '0 = water 1 = no data 2 = land',
-            'acolite-product': 'FLAGS',
-            'acolite-key': 'FLAGS',
-            'dtype': 'uint8',
-            'toa': True,
-            'bands': [],
-        },
-        'spm655': {
-            'assets': ['DN', 'C1'],
-            'description': 'Suspended Sediment Concentration 655nm',
-            'acolite-product': 'SPM_NECHAD_655',
-            'acolite-key': 'SPM_NECHAD_655',
-            'offset': 50.,
-            'gain': 0.005,
-            'dtype': 'int16',
-            'toa': True,
-            'bands': [],
-        },
-        'turbidity': {
-            'assets': ['DN', 'C1'],
-            'description': 'Blended Turbidity',
-            'acolite-product': 'T_DOGLIOTTI',
-            'acolite-key': 'T_DOGLIOTTI',
-            'offset': 50.,
-            'gain': 0.005,
-            'dtype': 'int16',
-            'toa': True,
-            'bands': [],
-        },
     }
+
+    gips.atmosphere.add_acolite_product_dicts(_products, 'DN', 'C1')
 
     for product, product_info in _products.iteritems():
         product_info['startdate'] = min(

--- a/gips/data/sentinel2/sentinel2.py
+++ b/gips/data/sentinel2/sentinel2.py
@@ -56,6 +56,8 @@ from gips import atmosphere
 * update system tests
 """
 
+_asset_type = 'L1C' # only one for the whole driver for now
+
 
 class sentinel2Repository(Repository):
     name = 'Sentinel2'
@@ -605,11 +607,11 @@ class sentinel2Data(Data):
     version = '0.1.0'
     Asset = sentinel2Asset
 
-    _asset_type = 'L1C' # only one for the whole driver for now
-
     _productgroups = {
         'Index': ['ndvi', 'evi', 'lswi', 'ndsi', 'bi', 'satvi', 'msavi2', 'vari', 'brgt',
-                  'ndti', 'crc', 'crcm', 'isti', 'sti'] # <-- tillage indices
+                  'ndti', 'crc', 'crcm', 'isti', 'sti'], # <-- tillage indices
+        'ACOLITE': ['rhow', 'oc2chl', 'oc3chl', 'fai',
+                    'spm655', 'turbidity', 'acoflags'],
     }
 
     _products = {
@@ -637,7 +639,7 @@ class sentinel2Data(Data):
     # add index products to _products
     _products.update(
         (p, {'description': d,
-             'assets': ['L1C'],
+             'assets': [_asset_type],
              'bands': [{'name': p, 'units': Data._unitless}]}
         ) for p, d in [
             ('ndvi',   'Normalized Difference Vegetation Index'),
@@ -661,6 +663,8 @@ class sentinel2Data(Data):
             ('sti',    'Standard Tillage Index'),
         ]
     )
+
+    atmosphere.add_acolite_product_dicts(_products, _asset_type)
 
     _product_dependencies = {
         'indices':      'ref',
@@ -702,10 +706,10 @@ class sentinel2Data(Data):
         return work
 
     def current_asset(self):
-        return self.assets[self._asset_type]
+        return self.assets[_asset_type]
 
     def current_sensor(self):
-        return self.sensors[self._asset_type]
+        return self.sensors[_asset_type]
 
 
     def load_image(self, product):

--- a/gips/test/sys/expected/landsat.py
+++ b/gips/test/sys/expected/landsat.py
@@ -121,17 +121,15 @@ t_process = {
     ]
 }
 
-# hashes correspond to all-cloud (hence masked) imagery
-# to be updated with gh-issue #218
 t_process_acolite = {
     'created': {
-        'landsat/tiles/012030/2017213/012030_2017213_LC8_acoflags.tif': -1859740248,
-        'landsat/tiles/012030/2017213/012030_2017213_LC8_fai.tif': -1038257960,
-        'landsat/tiles/012030/2017213/012030_2017213_LC8_oc2chl.tif': 1758567336,
-        'landsat/tiles/012030/2017213/012030_2017213_LC8_oc3chl.tif': -42455946,
-        'landsat/tiles/012030/2017213/012030_2017213_LC8_rhow.tif': -2063068590,
-        'landsat/tiles/012030/2017213/012030_2017213_LC8_spm655.tif': 319134655,
-        'landsat/tiles/012030/2017213/012030_2017213_LC8_turbidity.tif': -857239291,
+        'landsat/tiles/012030/2017213/012030_2017213_LC8_acoflags.tif': -514981863,
+        'landsat/tiles/012030/2017213/012030_2017213_LC8_fai.tif': -1820016301,
+        'landsat/tiles/012030/2017213/012030_2017213_LC8_oc2chl.tif': -794776169,
+        'landsat/tiles/012030/2017213/012030_2017213_LC8_oc3chl.tif': 337875725,
+        'landsat/tiles/012030/2017213/012030_2017213_LC8_rhow.tif': 1044772611,
+        'landsat/tiles/012030/2017213/012030_2017213_LC8_spm655.tif': 1437263134,
+        'landsat/tiles/012030/2017213/012030_2017213_LC8_turbidity.tif': -1347918033,
     },
     'updated': {
         'landsat/stage': None,

--- a/gips/test/sys/expected/sentinel2.py
+++ b/gips/test/sys/expected/sentinel2.py
@@ -175,3 +175,19 @@ t_stats = {
     },
     'ignored': _extraction_noise,
 }
+
+t_process_acolite = {
+    'compare_stderr': False,
+    'updated': {
+        'sentinel2/stage': None,
+        'sentinel2/tiles/19TCH/2017010': None,
+    },
+    'created': {
+        # TODO
+    },
+    'ignored': _extraction_noise + [
+        'gips-inv-db.sqlite3',
+        'sentinel2/tiles/19TCH/2017010/S2A_MSIL1C_20170110T153611_N0204_R111_T19TCH_20170110T154029.zip',
+        'sentinel2/tiles/19TCH/2017010/S2A_MSIL1C_20170110T153611_N0204_R111_T19TCH_20170110T154029.zip.index',
+    ],
+}

--- a/gips/test/sys/t_sentinel2.py
+++ b/gips/test/sys/t_sentinel2.py
@@ -84,6 +84,7 @@ def t_stats(setup_fixture, clean_repo_env, output_tfe, expected):
 
 @slow
 @acolite
+@pytest.mark.skip(reason="Overflows in zlib.crc32")
 def t_process_acolite(setup_fixture, repo_env, expected):
     """Generate acolite products."""
     aco_args = list(STD_ARGS) + \

--- a/gips/test/sys/t_sentinel2.py
+++ b/gips/test/sys/t_sentinel2.py
@@ -51,10 +51,6 @@ def t_process(setup_fixture, repo_env, expected):
     """Test `gips_process`, confirming products are created."""
     process_actual = repo_env.run('gips_process', *PROD_ARGS)
     inventory_actual = envoy.run('gips_inventory ' + ' '.join(STD_ARGS))
-    # just to make updating the tests less painful
-    if pytest.config.getoption("--expectation-format"):
-        print ('standard output (expectation format, post-processing gips_inventory): """' +
-               re.sub('\\\\n', '\n', repr(inventory_actual.std_out))[2:-1] + '"""')
     assert (expected == process_actual
             and expected._inv_stdout == inventory_actual.std_out)
 
@@ -84,4 +80,13 @@ def t_stats(setup_fixture, clean_repo_env, output_tfe, expected):
     actual = gtfe.run('gips_stats', OUTPUT_DIR)
 
     # check for correct stats content
+    assert expected == actual
+
+@slow
+@acolite
+def t_process_acolite(setup_fixture, repo_env, expected):
+    """Generate acolite products."""
+    aco_args = list(STD_ARGS) + \
+               '-p rhow fai oc2chl oc3chl spm655 turbidity acoflags'.split()
+    actual = repo_env.run('gips_process', *aco_args)
     assert expected == actual


### PR DESCRIPTION
* moved the product dicts to gips.atmosphere to reduce boilerplate.
* two internal assumptions about landsat in the acolite processing function were turned into arguments, so s2 could call it in an s2 way
* it ran over time budget so I didn't add an acolite test for sentinel-2, can do that presently if it's needed