### PR TITLE
Use an explicit asset type for reading metadata and data

### DIFF
--- a/gips/data/landsat/landsat.py
+++ b/gips/data/landsat/landsat.py
@@ -682,11 +682,7 @@ class landsatData(Data):
 
         start = datetime.now()
 
-        assets = set() # assets needed for this process() run
-        for key, val in products.requested.items():
-            assets.update(self._products[val[0]]['assets'])
-
-        if assets == set(['C1', 'DN']):
+        if set(self.assets.keys()) == set(['C1', 'DN']):
             if 'C1' in self.assets: # prefer C1
                 asset = 'C1'
             elif 'DN' in self.assets:
@@ -696,11 +692,11 @@ class landsatData(Data):
                     'No valid asset found for C1 nor DN for {} {}'.format(
                         self.basename))
         else:
-            if len(assets) > 1:
+            if len(self.assets) > 1:
                 # TODO document the reason why not
                 raise ValueError("Cannot create products from"
                                  " this combination of assets:  {}".format(assets))
-            asset = list(assets)[0]
+            asset = self.assets.keys()[0]
 
         # TODO: De-hack this
         # Better approach, but needs some thought, is to loop over assets

--- a/gips/data/landsat/landsat.py
+++ b/gips/data/landsat/landsat.py
@@ -678,6 +678,10 @@ class landsatData(Data):
         """ Make sure all products have been processed """
         products = super(landsatData, self).process(products, overwrite, **kwargs)
         if len(products) == 0:
+            verbose_out("Skipping processing; no products requested.", 5)
+            return
+        if len(self.assets) == 0:
+            verbose_out("Skipping processing; no assets found.", 5)
             return
 
         start = datetime.now()


### PR DESCRIPTION
Second verse, same as the first:  This fixes #407 by using an explicit asset type for reading metadata and data.  Also removes redundant product dependency check.