### PR TITLE
fixes #85 and DRYs out versioning

### DIFF
--- a/gips/data/core.py
+++ b/gips/data/core.py
@@ -259,9 +259,10 @@ class Asset(object):
     def updated(self, newasset):
         '''
         Compare the version info for this asset (self) to that of newasset.
-        Return true if newasset version is greater.
+        Return whether the newasset version is greater than self's version.
         '''
-        return false
+        raise NotImplementedError("{} driverdoes not support versioning"
+                                  .format(self.Repository.name))
 
     ##########################################################################
     # Child classes should not generally have to override anything below here
@@ -562,7 +563,7 @@ class Asset(object):
             if not os.path.exists(newfilename):
                 # check if another asset exists
                 existing = cls.discover(asset.tile, d, asset.asset)
-                if len(existing) > 0 and (not update or not existing[0].updated(asset)):
+                if len(existing) > 0 and not update:
                     # gatekeeper case:  No action taken because existing assets are in the way
                     VerboseOut('%s: other version(s) already exists:' % bname, 1)
                     for ef in existing:
@@ -572,9 +573,8 @@ class Asset(object):
                     # update case:  Remove existing outdated assets and install the new one
                     VerboseOut('%s: removing other version(s):' % bname, 1)
                     for ef in existing:
-                        assert ef.updated(asset), 'Asset is not updated version'
                         VerboseOut('\t%s' % os.path.basename(ef.filename), 1)
-                        with utils.error_handler('Unable to remove old version ' + ef.filename):
+                        with utils.error_handler('Unable to remove existing file: ' + ef.filename):
                             os.remove(ef.filename)
                     files = glob.glob(os.path.join(tpath, '*'))
                     for f in set(files).difference([ef.filename]):

--- a/gips/data/core.py
+++ b/gips/data/core.py
@@ -267,7 +267,8 @@ class Asset(object):
             'newasset' _version greater than existing _version.
 
         '''
-        return (self.sensor == newasset.sensor and
+        return (self.asset == newasset.asset and
+                self.sensor == newasset.sensor and
                 self.tile == newasset.tile and
                 self.date == newasset.date and
                 self._version < newasset._version)

--- a/gips/data/core.py
+++ b/gips/data/core.py
@@ -255,13 +255,22 @@ class Asset(object):
         self.sensor = ''
         # dictionary of existing products in asset {'product name': [filename(s)]}
         self.products = {}
+        # gips interpretation of the version of the asset
+        self._version = 1
 
     def updated(self, newasset):
         '''
-        Compare the version info for this asset (self) to that of newasset.
-        Return true if newasset version is greater.
+        Return:
+            'newasset' and existing represent the same data (time,space,sensor)
+            AND
+            'newasset' _version greater than existing _version.
+
         '''
-        return false
+        return (self.sensor == newasset.sensor and
+                self.tile == newasset.tile and
+                self.date == newasset.date and
+                self._version < newasset._version)
+
 
     ##########################################################################
     # Child classes should not generally have to override anything below here

--- a/gips/data/core.py
+++ b/gips/data/core.py
@@ -572,6 +572,9 @@ class Asset(object):
             newfilename = os.path.join(tpath, bname)
             if not os.path.exists(newfilename):
                 # check if another asset exists
+                # QUESTION: can it be that len(existing) > 1?
+                # IF NOT, then seems like some of these for-loops could go, and
+                # the overall logic could be simplified.
                 existing = cls.discover(asset.tile, d, asset.asset)
                 if len(existing) > 0 and (not update or not existing[0].updated(asset)):
                     # gatekeeper case:  No action taken because other assets exist
@@ -585,7 +588,14 @@ class Asset(object):
                     VerboseOut('%s: removing other version(s):' % bname, 1)
                     for ef in existing:
                         if not ef.updated(asset):
-                            'Asset is not updated version'
+                            utils.verbose_out(
+                                'Asset {} is not updated version of {}.'
+                                .format(ef.filename, asset.filename) +
+                                ' Remove existing asset to replace.', 2
+                            )
+                            # NOTE: This return makes sense iff len(existing)
+                            # cannot be greater than 1
+                            return (None, 0)
                         VerboseOut('\t%s' % os.path.basename(ef.filename), 1)
                         errmsg = 'Unable to remove existing version: ' + ef.filename
                         with utils.error_handler(errmsg):

--- a/gips/data/core.py
+++ b/gips/data/core.py
@@ -572,10 +572,16 @@ class Asset(object):
             newfilename = os.path.join(tpath, bname)
             if not os.path.exists(newfilename):
                 # check if another asset exists
-                # QUESTION: can it be that len(existing) > 1?
-                # IF NOT, then seems like some of these for-loops could go, and
-                # the overall logic could be simplified.
+                # QUESTION: Can it be that len(existing) > 1?
+                # Not changing much now, but adding an immediate assert to
+                # verify that there can only be one-or-none of an asset in the
+                # archive (2017-09-29).  Assuming it isn't a problem, we could
+                # drop some of these for-loops.
                 existing = cls.discover(asset.tile, d, asset.asset)
+                assert len(existing) in (0, 1), (
+                    'Apparently there can be more than one asset file for a'
+                    ' given ({}, {}, {}).'.format(asset.tile, d, asset.asset)
+                )
                 if len(existing) > 0 and (not update or not existing[0].updated(asset)):
                     # gatekeeper case:  No action taken because other assets exist
                     VerboseOut('%s: other version(s) already exists:' % bname, 1)

--- a/gips/data/landsat/landsat.py
+++ b/gips/data/landsat/landsat.py
@@ -280,6 +280,7 @@ class landsatAsset(Asset):
 
         if self.sensor not in self._sensors.keys():
             raise Exception("Sensor %s not supported: %s" % (self.sensor, filename))
+        self._version = self.version
 
     @classmethod
     def query_service(cls, asset, tile, date):
@@ -351,15 +352,6 @@ class landsatAsset(Asset):
                     os.path.join(stage_dir, granules[0]),
                 )
 
-    def updated(self, newasset):
-        '''
-        Compare the version for this to that of newasset.
-        Return true if newasset version is greater.
-        '''
-        return (self.sensor == newasset.sensor and
-                self.tile == newasset.tile and
-                self.date == newasset.date and
-                self.version < newasset.version)
 
 def unitless_bands(*bands):
     return [{'name': b, 'units': Data._unitless} for b in bands]

--- a/gips/data/merra/merra.py
+++ b/gips/data/merra/merra.py
@@ -175,7 +175,7 @@ class merraAsset(Asset):
         self.tile = 'h01v01'
         parts = basename(filename).split('.')
         self.asset = parts[1].split('_')[2].upper()
-        self.version = int(parts[0].split('_')[1])
+        self._version = int(parts[0].split('_')[1])
         if self.asset == "ASM":
             # assign date of static data sets
             self.date = self._assets[self.asset]['startdate']
@@ -258,16 +258,6 @@ class merraAsset(Asset):
             utils.verbose_out('Retrieved %s' % basename, 2)
 
         return retrieved_filenames
-
-    def updated(self, newasset):
-        '''
-        Compare the version for this to that of newasset.
-        Return true if newasset version is greater.
-        '''
-        return (self.sensor == newasset.sensor and
-                self.tile == newasset.tile and
-                self.date == newasset.date and
-                self.version < newasset.version)
 
 
 class merraData(Data):

--- a/gips/data/modis/modis.py
+++ b/gips/data/modis/modis.py
@@ -177,7 +177,7 @@ class modisAsset(Asset):
 
         collection = int(parts[3])
         file_version = int(parts[4])
-        self.version = float('{}.{}'.format(collection, file_version))
+        self._version = float('{}.{}'.format(collection, file_version))
 
 
     @classmethod
@@ -249,17 +249,6 @@ class modisAsset(Asset):
                 retrieved_filenames.append(outpath)
 
         return retrieved_filenames
-
-
-    def updated(self, newasset):
-        '''
-        Compare the version for this to that of newasset.
-        Return true if newasset version is greater.
-        '''
-        return (self.sensor == newasset.sensor and
-                self.tile == newasset.tile and
-                self.date == newasset.date and
-                self.version < newasset.version)
 
 
 class modisData(Data):

--- a/gips/data/prism/prism.py
+++ b/gips/data/prism/prism.py
@@ -116,7 +116,7 @@ class prismAsset(Asset):
         if 0 == len(filenames):
             return None, None
         # choose the one that has the most favorable stability & version values (usually only one)
-        return max(filenames, key=(lambda x: prismAsset(x).ver_stab)), None
+        return max(filenames, key=(lambda x: prismAsset(x)._version)), None
 
 
     @classmethod

--- a/gips/data/prism/prism.py
+++ b/gips/data/prism/prism.py
@@ -156,20 +156,9 @@ class prismAsset(Asset):
         self.scale = scale
         self.version = version
         self.stability = stability
-        self.ver_stab = self._stab_score[self.stability] * .01 + int(self.version[1:])
+        self._version = self._stab_score[self.stability] * .01 + int(self.version[1:])
         # only one tile
         self.tile = 'CONUS'
-
-    def updated(self, newasset):
-        '''
-        Compare the version for this to that of newasset.
-        Return true if newasset version is greater.
-        '''
-        return (self.sensor == newasset.sensor and
-                self.tile == newasset.tile and
-                self.date == newasset.date and
-                self.asset == self.asset and
-                self.ver_stab < newasset.ver_stab)
 
     def datafiles(self):
         datafiles = super(prismAsset, self).datafiles()

--- a/gips/data/sar/sar.py
+++ b/gips/data/sar/sar.py
@@ -209,7 +209,7 @@ class sarAsset(Asset):
         self.tile = m.group('tile')
         self.sensor = m.group('satellite') + m.group('mode')
 
-        self.version = int(m.group('serialno'))
+        self._version = int(m.group('serialno'))
 
         self.is_cycle = m.group('year_or_cycle') == 'C'
         self.cyid = int(m.group('cyid'))

--- a/gips/data/sentinel2/sentinel2.py
+++ b/gips/data/sentinel2/sentinel2.py
@@ -228,6 +228,9 @@ class sentinel2Asset(Asset):
         self.date = datetime.date(*[int(i) for i in match.group('year', 'mon', 'day')])
         self.time = datetime.time(*[int(i) for i in match.group('hour', 'min', 'sec')])
         self.set_style_regular_expressions()
+        self._version = int(''.join(
+            match.group('pyear', 'pmon', 'pday', 'phour', 'pmin', 'psec')
+        ))
 
 
     def set_style_regular_expressions(self):
@@ -426,17 +429,6 @@ class sentinel2Asset(Asset):
                 .format(file_name)
             )
         return list(tiles)
-
-
-    def updated(self, newasset):
-        '''
-        Compare the version for this to that of newasset.
-        Return true if newasset version is greater.
-        '''
-        return (self.sensor == newasset.sensor and
-                self.tile == newasset.tile and
-                self.date == newasset.date and
-                self.version < newasset.version)
 
 
     def xml_subtree(self, md_file_type, subtree_tag):


### PR DESCRIPTION
Now drivers only need to set `self._version` to get the default version handling behavior.

Example for possible over-ride might be to consider `C1` and `DN` equivalent in the landsat driver.