### PR TITLE
Moving landsat-specific get_geometry code to landsat driver

### DIFF
--- a/gips/data/core.py
+++ b/gips/data/core.py
@@ -310,15 +310,10 @@ class Asset(object):
         respective 'tiles.shp' file as WKT. Needs to be extended for
         untiled assets.
         """
-        # If tileID is a number, drop leading 0
-        try:
-            tile_num = int(self.tile)
-        except:
-            tile_num = self.tile
 
         v = gippy.GeoVector(self.Repository.get_setting("tiles"))
         v.SetPrimaryKey(self.Repository._tile_attribute)
-        feat = v[tile_num]
+        feat = v[self.tile]
 
         return feat.WKT()
 

--- a/gips/data/landsat/landsat.py
+++ b/gips/data/landsat/landsat.py
@@ -431,6 +431,16 @@ class landsatAsset(Asset):
                     os.path.join(stage_dir, granules[0]),
                 )
 
+    def get_geometry(self):
+        """Get the geometry of the asset"""
+        tile_num = int(self.tile)
+
+        v = gippy.GeoVector(self.Repository.get_setting("tiles"))
+        v.SetPrimaryKey(self.Repository._tile_attribute)
+        feat = v[tile_num]
+
+        return feat.WKT()
+
 
 def unitless_bands(*bands):
     return [{'name': b, 'units': Data._unitless} for b in bands]


### PR DESCRIPTION
This moves the landsat specific "check if tile is an int" functionality into the landsat driver.