### PR TITLE
453 & 439 add several indices as separate products to modis

### DIFF
--- a/gips/data/modis/modis.py
+++ b/gips/data/modis/modis.py
@@ -1072,10 +1072,8 @@ class modisData(Data):
             utils.verbose_out(' -> {}: processed in {}'.format(
                 os.path.basename(fname), datetime.datetime.now() - start), level=1)
 
-        # TODO have to dig it out via products.groups['Index'], once I trust it
         # process some index products (not all, see above)
-        requested_ipt = list(
-                set(products.requested.keys()) & set(self._productgroups['Index']))
+        requested_ipt = products.groups()['Index'].keys()
         if requested_ipt:
             model_pt = requested_ipt[0] # all should be similar
             asset, version, _, _, allsds = self.asset_check(model_pt)

--- a/gips/data/modis/modis.py
+++ b/gips/data/modis/modis.py
@@ -1092,8 +1092,8 @@ class modisData(Data):
             # GIPPY uses expected band names to find data
             img.SetBandName('BLUE', 2) # array index 2 = band number 3
             img.SetBandName('GREEN', 3)
-            img.SetBandName('SWIR1', 4)
-            img.SetBandName('SWIR2', 5)
+            img.SetBandName('SWIR1', 5)
+            img.SetBandName('SWIR2', 6)
 
             sensor = self._products[model_pt]['sensor']
             prod_spec = {pt: self.temp_product_filename(sensor, pt)

--- a/gips/data/modis/modis.py
+++ b/gips/data/modis/modis.py
@@ -276,7 +276,7 @@ class modisData(Data):
         "Nadir BRDF-Adjusted 16-day": ['indices', 'quality'],
         "Terra/Aqua Daily": ['snow', 'temp', 'obstime', 'fsnow'],
         "Terra 8-day": ['ndvi8', 'temp8tn', 'temp8td'],
-        "Indices": [pt for (pt, _) in _index_products],
+        "Index": [pt for (pt, _) in _index_products],
     }
 
     _products = { # note indices products are added in below
@@ -433,7 +433,7 @@ class modisData(Data):
         for key, val in products.requested.items():
             # TODO replace val[0] below with this more meaningful name
             prod_type = val[0]
-            if prod_type in self._productgroups['Indices']:
+            if prod_type in self._productgroups['Index']:
                 continue # indices handled differently below
             start = datetime.datetime.now()
             asset, version, missingassets, availassets, allsds = \
@@ -465,7 +465,7 @@ class modisData(Data):
             # now with QC layer!
             if val[0] == "indices":
                 depr_msg = ("'indices' is deprecated, and may be removed in"
-                    " the future.  See the Indices product group instead.")
+                    " the future.  See the Index product group instead.")
                 utils.verbose_out(depr_msg, 2, stream=sys.stderr)
                 VERSION = "2.0"
                 meta['VERSION'] = VERSION
@@ -1060,10 +1060,10 @@ class modisData(Data):
             utils.verbose_out(' -> {}: processed in {}'.format(
                 os.path.basename(fname), datetime.datetime.now() - start), level=1)
 
-        # TODO have to dig it out via products.groups['Indices'], once I trust it
+        # TODO have to dig it out via products.groups['Index'], once I trust it
         # process some index products (not all, see above)
         requested_ipt = list(
-                set(products.requested.keys()) & set(self._productgroups['Indices']))
+                set(products.requested.keys()) & set(self._productgroups['Index']))
         if requested_ipt:
             model_pt = requested_ipt[0] # all should be similar
             asset, version, _, _, allsds = self.asset_check(model_pt)

--- a/gips/data/modis/modis.py
+++ b/gips/data/modis/modis.py
@@ -456,7 +456,7 @@ class modisData(Data):
                 imgout = gippy.GeoImage(fname)
 
             if val[0] == "quality":
-                if versions[asset] != 6:
+                if version != 6:
                     raise Exception('product version not supported')
                 os.symlink(allsds[0], fname)
                 imgout = gippy.GeoImage(fname)
@@ -464,12 +464,15 @@ class modisData(Data):
             # LAND VEGETATION INDICES PRODUCT
             # now with QC layer!
             if val[0] == "indices":
+                depr_msg = ("'indices' is deprecated, and may be removed in"
+                    " the future.  See the Indices product group instead.")
+                utils.verbose_out(depr_msg, 2, stream=sys.stderr)
                 VERSION = "2.0"
                 meta['VERSION'] = VERSION
                 refl = gippy.GeoImage(allsds)
                 missing = 32767
 
-                if versions[asset] == 6:
+                if version == 6:
                     redimg = refl[7].Read()
                     nirimg = refl[8].Read()
                     bluimg = refl[9].Read()

--- a/gips/data/modis/modis.py
+++ b/gips/data/modis/modis.py
@@ -1098,10 +1098,10 @@ class modisData(Data):
             img = gippy.GeoImage(allsds[7:]) # don't need the QC bands
 
             # GIPPY uses expected band names to find data
-            img.SetBandName('BLUE', 4)
-            img.SetBandName('GREEN', 5)
-            img.SetBandName('SWIR1', 6)
-            img.SetBandName('SWIR2', 7)
+            img.SetBandName('BLUE', 2) # array index 2 = band number 3
+            img.SetBandName('GREEN', 3)
+            img.SetBandName('SWIR1', 4)
+            img.SetBandName('SWIR2', 5)
 
             sensor = self._products[model_pt]['sensor']
             prod_spec = {pt: self.temp_product_filename(sensor, pt)

--- a/gips/data/modis/modis.py
+++ b/gips/data/modis/modis.py
@@ -397,8 +397,9 @@ class modisData(Data):
     def asset_check(self, prod_type):
         """Is an asset available for the current scene and product?
 
-        Returns the last found asset, or else None, its version, and the
-        complete lists of missing and available assets.
+        Returns the last found asset, or else None, its version, the
+        complete lists of missing and available assets, and lastly, an array
+        of pseudo-filepath strings suitable for consumption by gdal/gippy.
         """
         # return values
         asset = None

--- a/gips/data/modis/modis.py
+++ b/gips/data/modis/modis.py
@@ -254,10 +254,22 @@ class modisAsset(Asset):
 
 # index product types and descriptions
 _index_products = [
-    ('ndti', 'Normalized Difference Tillage Index'),
-    ('crc',  'Crop Residue Cover (uses BLUE)'),
-    ('crcm', 'Crop Residue Cover, Modified (uses GREEN)'),
-    ('sti',  'Standard Tillage Index'),
+    # duplicated in sentinel2 and landsat; may be worth it to DRY out
+    ('ndvi',   'Normalized Difference Vegetation Index'),
+    ('evi',    'Enhanced Vegetation Index'),
+    ('lswi',   'Land Surface Water Index'),
+    ('ndsi',   'Normalized Difference Snow Index'),
+    ('bi',     'Brightness Index'),
+    ('satvi',  'Soil-Adjusted Total Vegetation Index'),
+    ('msavi2', 'Modified Soil-adjusted Vegetation Index'),
+    ('vari',   'Visible Atmospherically Resistant Index'),
+    ('brgt',   'VIS and NIR reflectance, weighted by'
+               'solar energy distribution.'),
+    ('ndti',   'Normalized Difference Tillage Index'),
+    ('crc',    'Crop Residue Cover (uses BLUE)'),
+    ('crcm',   'Crop Residue Cover, Modified (uses GREEN)'),
+    ('isti',   'Inverse Standard Tillage Index'),
+    ('sti',    'Standard Tillage Index'),
 ]
 
 _index_product_entries = {
@@ -1075,11 +1087,23 @@ class modisData(Data):
                               ' but found {}'.format(version))
             img = gippy.GeoImage(allsds[7:]) # don't need the QC bands
 
-            # GIPPY uses expected band names to find data
-            img.SetBandName('BLUE', 2) # array index 2 = band number 3
-            img.SetBandName('GREEN', 3)
-            img.SetBandName('SWIR1', 5)
-            img.SetBandName('SWIR2', 6)
+            # GIPPY uses expected band names to find data:
+            """
+            index (ie img[i])
+            |  band num
+            |   |   wavelength  name
+            0   1   620 - 670   RED
+            1   2   841 - 876   NIR
+            2   3   459 - 479   BLUE
+            3   4   545 - 565   GREEN
+            4   5   1230 - 1250 CIRRUS (not used by gippy)
+            5   6   1628 - 1652 SWIR1
+            6   7   2105 - 2155 SWIR2
+            """
+            # SetBandName goes by band number, not index
+            [img.SetBandName(name, i) for (name, i) in [
+                ('RED',   1), ('NIR',   2), ('BLUE',  3),
+                ('GREEN', 4), ('SWIR1', 6), ('SWIR2', 7)]]
 
             sensor = self._products[model_pt]['sensor']
             prod_spec = {pt: self.temp_product_filename(sensor, pt)

--- a/gips/data/modis/modis.py
+++ b/gips/data/modis/modis.py
@@ -82,6 +82,7 @@ class modisAsset(Asset):
     _asset_re_tail = '\.A.{7}\.h.{2}v.{2}\..{3}\..{13}\.hdf$'
 
     _assets = {
+        #Band info:  https://modis.gsfc.nasa.gov/about/specifications.php
         'MCD43A4': {
             'pattern': '^MCD43A4' + _asset_re_tail,
             'url': 'https://e4ftl01.cr.usgs.gov/MOTA/MCD43A4.006',
@@ -250,15 +251,6 @@ class modisAsset(Asset):
 
         return retrieved_filenames
 
-"""
-Info about bands:
-    https://modis.gsfc.nasa.gov/about/specifications.php#1
-Landsat can be used to roughly map colors to bands:
-    https://landsat.usgs.gov/what-are-band-designations-landsat-satellites
-Example index values for the MCD43A4 refl object which starts with
-QC bands; refl[7:] is modis land bands 1-7:
-    {'blue': 9, 'green': 10, 'swir1': 11, 'swir2': 12}
-"""
 _tillage_product_types = ('ndti', 'crc', 'crcm', 'sti')
 
 _tp_descriptions = {

--- a/gips/data/sentinel2/sentinel2.py
+++ b/gips/data/sentinel2/sentinel2.py
@@ -684,6 +684,7 @@ class sentinel2Data(Data):
              'assets': [_asset_type],
              'bands': [{'name': p, 'units': Data._unitless}]}
         ) for p, d in [
+            # duplicated in modis and landsat; may be worth it to DRY out
             ('ndvi',   'Normalized Difference Vegetation Index'),
             ('evi',    'Enhanced Vegetation Index'),
             ('lswi',   'Land Surface Water Index'),


### PR DESCRIPTION
This fixes #453 and fixes #439 by building off the work for #439.  Removes refl, deprecates indices, replaces the latter with individual products in a new 'Index' product group.
