### PR TITLE
252 prism downloads too much

### DIFF
--- a/gips/data/prism/prism.py
+++ b/gips/data/prism/prism.py
@@ -88,8 +88,8 @@ class prismAsset(Asset):
     }
     _stab_score = {
         'stable': 3,
-        'early': 2,
-        'provisional': 1,
+        'provisional': 2,
+        'early': 1,
     }
 
     @classmethod


### PR DESCRIPTION
(This includes commits from PR #475 because they were blockers.)

This fixes PRISM nuisance downloading #252 and an undocumented bug in versioning where the meanings of "early" and "provisional" were swapped. 