### PR TITLE
464 replace scripttest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -73,6 +73,9 @@ def pytest_addoption(parser):
     parser.addoption(
         "--expectation-format", action="store_true", help=help_str)
 
+    parser.addoption('--record', action='store', default=None,
+                     help="Pass in a filename for expecations"
+                          " to be written to that filename.")
 
 def pytest_configure(config):
     """Process user config & command-line options."""
@@ -80,6 +83,9 @@ def pytest_configure(config):
     level = ('warning' if raw_level is None else raw_level).upper()
     root_logger.setLevel(level)
 
+    # TODO complain here if --record or --record-dir are wrong:
+    #   * --record file should not exist
+    #   * --record-dir should exist
     dr = str(config.getini('data-repo'))
     if not dr:
         raise ValueError("No value specified for 'data-repo' in pytest.ini")

--- a/conftest.py
+++ b/conftest.py
@@ -76,6 +76,10 @@ def pytest_addoption(parser):
     parser.addoption('--record', action='store', default=None,
                      help="Pass in a filename for expecations"
                           " to be written to that filename.")
+    # TODO cleanup may not need to be implemented at all
+    #parser.addoption('--cleanup-on-failure', action='store_true',
+    #        help="Normally cleanup is skipped on failure so you can examine"
+    #             " files; pass this option to cleanup even on failure.")
 
 def pytest_configure(config):
     """Process user config & command-line options."""

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,4 +4,5 @@ pytest-timeout
 pytest-mock
 pytest-django
 scripttest
-envoy
+envoy # deprecated
+sh

--- a/gips/test/int/t_chirps.py
+++ b/gips/test/int/t_chirps.py
@@ -40,7 +40,7 @@ def scene_dir_setup():
         os.remove(target_product_fp)
     if use_fake_asset:
         os.remove(target_asset_fp)
-        [os.rmdir(d) for d in made_dirs]
+        [os.rmdir(d) for d in reversed(made_dirs)] # <- remove in correct order
 
 @pytest.mark.django_db
 def t_chirps_product_symlink(mocker, scene_dir_setup):

--- a/gips/test/sys/conftest.py
+++ b/gips/test/sys/conftest.py
@@ -1,0 +1,33 @@
+#from __future__ import print_function
+
+### WHERE I LEFT THIS:
+# working on optional test teardown (removal of created files) on test failure/error
+# two approaches, probably going with the second one:
+# PS this conftest.py only applies to system tests due to location; nifty!
+
+# https://stackoverflow.com/questions/28198585/pytest-how-to-take-action-on-test-failure/47908872#47908872
+"""
+def pytest_exception_interact(node, call, report):
+    print('pytest_exception_interact')
+    import pdb; pdb.set_trace()
+    if report.failed:
+        print("node:", node)
+        print("call:", call)
+        print("report:", report)
+        # report.outcome == 'failed'
+        #import pdb; pdb.set_trace()
+"""
+
+# https://docs.pytest.org/en/latest/example/simple.html#making-test-result-information-available-in-fixtures
+"""
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    # execute all other hooks to obtain the report object
+    outcome = yield
+    rep = outcome.get_result()
+
+    # set a report attribute for each phase of a call, which can
+    # be "setup", "call", "teardown"
+
+    setattr(item, "rep_" + rep.when, rep)
+"""

--- a/gips/test/sys/expected/merra.py
+++ b/gips/test/sys/expected/merra.py
@@ -42,15 +42,60 @@ SENSORS\x1b[0m
 
 t_process = {
     # test this too?  'frland': [],
-    'patm': [],
-    'prcp': [],
-    'rhum': [],
-    'shum': [],
-    'srad': [],
-    'tave': [],
-    'tmax': [],
-    'tmin': [],
-    'wind': [],
+    # t_process[srad] recording:
+    'srad':
+        [('data-root/merra/tiles/h01v01/2015135/h01v01_2015135_merra_srad.tif',
+          'hash',
+          'sha256',
+          '882a44af70e337bf905c8695936f101792a518507a4304b23781a2f30aaabab4')],
+    # t_process[tave] recording:
+    'tave':
+        [('data-root/merra/tiles/h01v01/2015135/h01v01_2015135_merra_tave.tif',
+          'hash',
+          'sha256',
+          '5185aebd7cda54157cad2ddbde9f6fec4871c1b85fe78d0738634ba0211f2c9b')],
+    # t_process[shum] recording:
+    'shum':
+        [('data-root/merra/tiles/h01v01/2015135/h01v01_2015135_merra_shum.tif',
+          'hash',
+          'sha256',
+          '558f567c1e931891553d396f81b2b90929ad48a0ae88fa95d3894eae23ab3eba')],
+    # t_process[rhum] recording:
+    'rhum':
+        [('data-root/merra/tiles/h01v01/2015135/h01v01_2015135_merra_rhum.tif',
+          'hash',
+          'sha256',
+          '058161eb8488f1fb3df7f5c8719833c9d68c56aa082d4605938f62c2ee0035f6')],
+    # t_process[tmin] recording:
+    'tmin':
+        [('data-root/merra/tiles/h01v01/2015135/h01v01_2015135_merra_tmin.tif',
+          'hash',
+          'sha256',
+          '35a850769a3bb8f5209574ea4835bf417d8f99024567f4af9cdee9e623d0c567')],
+    # t_process[tmax] recording:
+    'tmax':
+        [('data-root/merra/tiles/h01v01/2015135/h01v01_2015135_merra_tmax.tif',
+          'hash',
+          'sha256',
+          '5963fcf346f388fc347355153996a078f1eb5ecbbc094394b72be382ba491865')],
+    # t_process[prcp] recording:
+    'prcp':
+        [('data-root/merra/tiles/h01v01/2015135/h01v01_2015135_merra_prcp.tif',
+          'hash',
+          'sha256',
+          '348fd7072ef0a8625f5268e29acbf3a69a959a412327102ef6558c992e62bc9f')],
+    # t_process[patm] recording:
+    'patm':
+        [('data-root/merra/tiles/h01v01/2015135/h01v01_2015135_merra_patm.tif',
+          'hash',
+          'sha256',
+          '7d9deca613973cb8ffb8f15a3dfa2013e6783556b520915e89b97fe41de638e3')],
+    # t_process[wind] recording:
+    'wind':
+        [('data-root/merra/tiles/h01v01/2015135/h01v01_2015135_merra_wind.tif',
+          'hash',
+          'sha256',
+          'a90c1d87fdb1c0926bd5b3004408a1f9d42ef08c38deb9d0572bc7536dbbf08a')],
 }
 
 t_project = {

--- a/gips/test/sys/expected/merra.py
+++ b/gips/test/sys/expected/merra.py
@@ -40,45 +40,17 @@ SENSORS\x1b[0m
 """
 }
 
-
 t_process = {
-    'updated': {
-        'merra/stage': None,
-        'merra/tiles/h01v01/2015135': None,
-    },
-    'created': {
-        'merra/tiles/h01v01/2015135/h01v01_2015135_merra_patm.tif': -832862627,
-        'merra/tiles/h01v01/2015135/h01v01_2015135_merra_prcp.tif': -1814551991,
-        'merra/tiles/h01v01/2015135/h01v01_2015135_merra_rhum.tif': 1203124684,
-        'merra/tiles/h01v01/2015135/h01v01_2015135_merra_shum.tif': -97846975,
-        'merra/tiles/h01v01/2015135/h01v01_2015135_merra_srad.tif': -1745572576,
-        'merra/tiles/h01v01/2015135/h01v01_2015135_merra_tave.tif': 165650774,
-        'merra/tiles/h01v01/2015135/h01v01_2015135_merra_tmax.tif': 463728356,
-        'merra/tiles/h01v01/2015135/h01v01_2015135_merra_tmin.tif': -1469140067,
-        'merra/tiles/h01v01/2015135/h01v01_2015135_merra_wind.tif': 1771906367,
-    },
-    'ignored': [
-        'gips-inv-db.sqlite3',
-    ],
-    '_inv_stdout': """\x1b[1mGIPS Data Inventory (v0.8.2)\x1b[0m
-Retrieving inventory for site NHseacoast-0
-
-\x1b[1mAsset Coverage for site NHseacoast-0\x1b[0m
-\x1b[1m
-Tile Coverage
-\x1b[4m  Tile      % Coverage   % Tile Used\x1b[0m
-  h01v01      100.0%        0.0%
-
-\x1b[1m\x1b[4m    DATE       ASM       FLX       RAD       SLV     Product  \x1b[0m
-\x1b[1m2015        
-\x1b[0m    135                 100.0%     100.0%     100.0%     \x1b[35mpatm\x1b[0m  \x1b[35mprcp\x1b[0m  \x1b[35mrhum\x1b[0m  \x1b[35mshum\x1b[0m  \x1b[35msrad\x1b[0m  \x1b[35mtave\x1b[0m  \x1b[35mtmax\x1b[0m  \x1b[35mtmin\x1b[0m  \x1b[35mwind\x1b[0m
-
-
-1 files on 1 dates
-\x1b[1m
-SENSORS\x1b[0m
-\x1b[35mmerra: Modern Era Retrospective-analysis for Research and Applications\x1b[0m
-""",
+    # test this too?  'frland': [],
+    'patm': [],
+    'prcp': [],
+    'rhum': [],
+    'shum': [],
+    'srad': [],
+    'tave': [],
+    'tmax': [],
+    'tmin': [],
+    'wind': [],
 }
 
 t_project = {

--- a/gips/test/sys/expected/modis.py
+++ b/gips/test/sys/expected/modis.py
@@ -28,62 +28,329 @@ SENSORS\x1b[0m
 
 
 t_process = {
-    'updated': {
-        'modis/stage': None,
-        'modis/tiles/h12v04/2012336': None,
-        'modis/tiles/h12v04/2012337': None,
-        'modis/tiles/h12v04/2012338': None,
-    },
-    'created': {
-        # Each None is a symlink; see prism for a way to test it more meaningfully.
-        'modis/tiles/h12v04/2012336/h12v04_2012336_MCD_quality.tif': None,
-        'modis/tiles/h12v04/2012337/h12v04_2012337_MCD_quality.tif': None,
-        'modis/tiles/h12v04/2012337/h12v04_2012337_MOD_temp8td.tif': None,
-        'modis/tiles/h12v04/2012337/h12v04_2012337_MOD_temp8tn.tif': None,
-        'modis/tiles/h12v04/2012338/h12v04_2012338_MCD_quality.tif': None,
-        'modis/tiles/h12v04/2012336/h12v04_2012336_MCD_fsnow.tif': -843500181,
-        'modis/tiles/h12v04/2012336/h12v04_2012336_MCD_indices.tif': -684782438,
-        'modis/tiles/h12v04/2012336/h12v04_2012336_MCD_snow.tif': 388495321,
-        'modis/tiles/h12v04/2012336/h12v04_2012336_MOD-MYD_obstime.tif': -661225282,
-        'modis/tiles/h12v04/2012336/h12v04_2012336_MOD-MYD_temp.tif': 1278807725,
-        'modis/tiles/h12v04/2012336/h12v04_2012336_MOD_clouds.tif': 161070470,
-        'modis/tiles/h12v04/2012337/h12v04_2012337_MCD_fsnow.tif': 297883486,
-        'modis/tiles/h12v04/2012337/h12v04_2012337_MCD_indices.tif': -1806386481,
-        'modis/tiles/h12v04/2012337/h12v04_2012337_MCD_snow.tif': -748640537,
-        'modis/tiles/h12v04/2012337/h12v04_2012337_MOD-MYD_obstime.tif': 348598487,
-        'modis/tiles/h12v04/2012337/h12v04_2012337_MOD-MYD_temp.tif': 1853031589,
-        'modis/tiles/h12v04/2012337/h12v04_2012337_MOD_clouds.tif': -832284681,
-        'modis/tiles/h12v04/2012337/h12v04_2012337_MOD_ndvi8.tif': -395723296,
-        'modis/tiles/h12v04/2012338/h12v04_2012338_MCD_fsnow.tif': -1930181337,
-        'modis/tiles/h12v04/2012338/h12v04_2012338_MCD_indices.tif': -521042334,
-        'modis/tiles/h12v04/2012338/h12v04_2012338_MCD_snow.tif': 387672365,
-        'modis/tiles/h12v04/2012338/h12v04_2012338_MOD-MYD_obstime.tif': -1046273330,
-        'modis/tiles/h12v04/2012338/h12v04_2012338_MOD-MYD_temp.tif': 207791084,
-        'modis/tiles/h12v04/2012338/h12v04_2012338_MOD_clouds.tif': 296967275,
-    },
-    'ignored': [ # contain site-specific data not applicable across users/configurations
-        'gips-inv-db.sqlite3',
-        'modis/tiles/h12v04/2012336/MCD43A2.A2012336.h12v04.006.2016112010833.hdf.index',
-        'modis/tiles/h12v04/2012336/MCD43A4.A2012336.h12v04.006.2016112010833.hdf.index',
-        'modis/tiles/h12v04/2012336/MOD10A1.A2012336.h12v04.005.2012339213007.hdf.index',
-        'modis/tiles/h12v04/2012336/MOD11A1.A2012336.h12v04.006.2016131164025.hdf.index',
-        'modis/tiles/h12v04/2012336/MYD10A1.A2012336.h12v04.005.2012340031954.hdf.index',
-        'modis/tiles/h12v04/2012336/MYD11A1.A2012336.h12v04.006.2016132100529.hdf.index',
-        'modis/tiles/h12v04/2012337/MCD43A2.A2012337.h12v04.006.2016112013509.hdf.index',
-        'modis/tiles/h12v04/2012337/MCD43A4.A2012337.h12v04.006.2016112013509.hdf.index',
-        'modis/tiles/h12v04/2012337/MOD09Q1.A2012337.h12v04.006.2015253024347.hdf.index',
-        'modis/tiles/h12v04/2012337/MOD10A1.A2012337.h12v04.005.2012340033542.hdf.index',
-        'modis/tiles/h12v04/2012337/MOD11A1.A2012337.h12v04.006.2016131185851.hdf.index',
-        'modis/tiles/h12v04/2012337/MOD11A2.A2012337.h12v04.006.2016137164847.hdf.index',
-        'modis/tiles/h12v04/2012337/MYD10A1.A2012337.h12v04.005.2012340112013.hdf.index',
-        'modis/tiles/h12v04/2012337/MYD11A1.A2012337.h12v04.006.2016132101831.hdf.index',
-        'modis/tiles/h12v04/2012338/MCD43A2.A2012338.h12v04.006.2016112020013.hdf.index',
-        'modis/tiles/h12v04/2012338/MCD43A4.A2012338.h12v04.006.2016112020013.hdf.index',
-        'modis/tiles/h12v04/2012338/MOD10A1.A2012338.h12v04.005.2012341091201.hdf.index',
-        'modis/tiles/h12v04/2012338/MOD11A1.A2012338.h12v04.006.2016131192106.hdf.index',
-        'modis/tiles/h12v04/2012338/MYD10A1.A2012338.h12v04.005.2012340142152.hdf.index',
-        'modis/tiles/h12v04/2012338/MYD11A1.A2012338.h12v04.006.2016132112414.hdf.index',
-    ],
+    # 'landcover' [], # is annual, not available for the scene under test
+    # weird symlink products:
+    # t_process[quality] recording:
+    'quality':
+        [('data-root/modis/tiles/h12v04/2012336/h12v04_2012336_MCD_quality.tif',
+          'symlink',
+          'HDF4_EOS:EOS_GRID:"',
+          '/data-root/modis/tiles/h12v04/2012336/MCD43A2.A2012336.h12v04.006.2016112010833.hdf":MOD_Grid_BRDF:Snow_BRDF_Albedo'),
+         ('data-root/modis/tiles/h12v04/2012337/h12v04_2012337_MCD_quality.tif',
+          'symlink',
+          'HDF4_EOS:EOS_GRID:"',
+          '/data-root/modis/tiles/h12v04/2012337/MCD43A2.A2012337.h12v04.006.2016112013509.hdf":MOD_Grid_BRDF:Snow_BRDF_Albedo'),
+         ('data-root/modis/tiles/h12v04/2012338/h12v04_2012338_MCD_quality.tif',
+          'symlink',
+          'HDF4_EOS:EOS_GRID:"',
+          '/data-root/modis/tiles/h12v04/2012338/MCD43A2.A2012338.h12v04.006.2016112020013.hdf":MOD_Grid_BRDF:Snow_BRDF_Albedo')],
+
+    # t_process[temp8tn] recording:
+    'temp8tn':
+        [('data-root/modis/tiles/h12v04/2012337/h12v04_2012337_MOD_temp8tn.tif',
+          'symlink',
+          'HDF4_EOS:EOS_GRID:"',
+          '/data-root/modis/tiles/h12v04/2012337/MOD11A2.A2012337.h12v04.006.2016137164847.hdf":MODIS_Grid_8Day_1km_LST:LST_Night_1km')],
+
+    # t_process[temp8td] recording:
+    'temp8td':
+        [('data-root/modis/tiles/h12v04/2012337/h12v04_2012337_MOD_temp8td.tif',
+          'symlink',
+          'HDF4_EOS:EOS_GRID:"',
+          '/data-root/modis/tiles/h12v04/2012337/MOD11A2.A2012337.h12v04.006.2016137164847.hdf":MODIS_Grid_8Day_1km_LST:LST_Day_1km')],
+
+    # normal products
+    # t_process[satvi] recording:
+    'satvi':
+        [('data-root/modis/tiles/h12v04/2012337/h12v04_2012337_MCD_satvi.tif',
+          'hash',
+          'sha256',
+          '94bee7cecf0f0a227fd8532223f86de10e01c3e39d1dd70b7675d91b3ca338a4'),
+         ('data-root/modis/tiles/h12v04/2012336/h12v04_2012336_MCD_satvi.tif',
+          'hash',
+          'sha256',
+          '6397669a6cd62bb39813b9000d93ba50f4cabe73aebf1e6444f4e3be9f630e19'),
+         ('data-root/modis/tiles/h12v04/2012338/h12v04_2012338_MCD_satvi.tif',
+          'hash',
+          'sha256',
+          '6124ee615a4f522fdf966a5479d03d87934908e5090a192192f9700020f24760')],
+
+    # t_process[ndti] recording:
+    'ndti':
+        [('data-root/modis/tiles/h12v04/2012338/h12v04_2012338_MCD_ndti.tif',
+          'hash',
+          'sha256',
+          '025ea7a9204ae8ad0952a92b386bf735dbbce8337e336843476d3f227cf1f1ab'),
+         ('data-root/modis/tiles/h12v04/2012337/h12v04_2012337_MCD_ndti.tif',
+          'hash',
+          'sha256',
+          'b6baa8c7a3996f680c4177e4157c9275dd895c8e6350afa6ef564e673bb6a5f0'),
+         ('data-root/modis/tiles/h12v04/2012336/h12v04_2012336_MCD_ndti.tif',
+          'hash',
+          'sha256',
+          'a1c4f1161e8a584257352e76160319c39aa4605dd565d388d0116e193773771f')],
+
+    # t_process[ndvi] recording:
+    'ndvi':
+        [('data-root/modis/tiles/h12v04/2012338/h12v04_2012338_MCD_ndvi.tif',
+          'hash',
+          'sha256',
+          'efbeae3a1c5e59ccd54b6108e275f9a8f0059162ac2797f4d69b00acb80147b3'),
+         ('data-root/modis/tiles/h12v04/2012336/h12v04_2012336_MCD_ndvi.tif',
+          'hash',
+          'sha256',
+          'b56d5c96229a1ad4cdcbd09db10b19a216b4cde8a0ffd184ee5cf01a35ab2b46'),
+         ('data-root/modis/tiles/h12v04/2012337/h12v04_2012337_MCD_ndvi.tif',
+          'hash',
+          'sha256',
+          'd9ff5d2f85ac9a267a8f6b1aca34f62b8196721e212b1e092f82ce9f1e208c61')],
+
+    # t_process[isti] recording:
+    'isti':
+        [('data-root/modis/tiles/h12v04/2012338/h12v04_2012338_MCD_isti.tif',
+          'hash',
+          'sha256',
+          'c0a38d1cd00de52eacd8abcda714bfdaa575787e27b40dc0472ffca5ab1696c0'),
+         ('data-root/modis/tiles/h12v04/2012337/h12v04_2012337_MCD_isti.tif',
+          'hash',
+          'sha256',
+          'b1759c1008e5914b955c4a9f55572baa8f7c0310677264a1057329e236d826cb'),
+         ('data-root/modis/tiles/h12v04/2012336/h12v04_2012336_MCD_isti.tif',
+          'hash',
+          'sha256',
+          '677182d186dac992b52b93239af0f419536075c7cd467864fa544bcde4b89e69')],
+
+    # t_process[ndvi8] recording:
+    'ndvi8':
+        [('data-root/modis/tiles/h12v04/2012337/h12v04_2012337_MOD_ndvi8.tif',
+          'hash',
+          'sha256',
+          '93db24c18886fbac0b87d1404a0c80606a599cc55b02d745a09ffb051b8131ac')],
+
+    # t_process[snow] recording:
+    'snow':
+        [('data-root/modis/tiles/h12v04/2012336/h12v04_2012336_MCD_snow.tif',
+          'hash',
+          'sha256',
+          'bea7315b736a75bcf37df86089679845ac597f3fba5d5cd6e79f5516b9657faa'),
+         ('data-root/modis/tiles/h12v04/2012337/h12v04_2012337_MCD_snow.tif',
+          'hash',
+          'sha256',
+          'de979c1a0c616d7889dd5fd45816849f9c08df54167d7f3b40301d6ac4495778'),
+         ('data-root/modis/tiles/h12v04/2012338/h12v04_2012338_MCD_snow.tif',
+          'hash',
+          'sha256',
+          '5d9bbfff1522e74165cdd677f1580e9eb2236c2c5922a796a6c9ee0db24ae05a')],
+
+    # t_process[fsnow] recording:
+    'fsnow':
+        [('data-root/modis/tiles/h12v04/2012336/h12v04_2012336_MCD_fsnow.tif',
+          'hash',
+          'sha256',
+          '853a5ca95f21c4a745e41e4acc46a71a74c74e0cdd1cae9ed3dd31b2fef1ddbd'),
+         ('data-root/modis/tiles/h12v04/2012337/h12v04_2012337_MCD_fsnow.tif',
+          'hash',
+          'sha256',
+          '3a5f7c95fe60e5789919cf55d7f8e652e4d668c6eb63eaa53a82249c0ea19c5a'),
+         ('data-root/modis/tiles/h12v04/2012338/h12v04_2012338_MCD_fsnow.tif',
+          'hash',
+          'sha256',
+          'd09b8a12ad17a7e715ae2e988fbf683e5fe2df46e97e9ac3ebb4444c8b1c169d')],
+
+    # t_process[crcm] recording:
+    'crcm':
+        [('data-root/modis/tiles/h12v04/2012338/h12v04_2012338_MCD_crcm.tif',
+          'hash',
+          'sha256',
+          'a45c2fb16d871a919e0c803f80e1f3b4ec831472d0466c33741fcf8e8150f6ba'),
+         ('data-root/modis/tiles/h12v04/2012337/h12v04_2012337_MCD_crcm.tif',
+          'hash',
+          'sha256',
+          '9aa80c0e1fa1b62b0a41aed42eeaf84632845d74f29594dfee55c22673b0a6f5'),
+         ('data-root/modis/tiles/h12v04/2012336/h12v04_2012336_MCD_crcm.tif',
+          'hash',
+          'sha256',
+          'a28c7d280fb8dfe0fe1cc003e1001457abdf14acc5545b2a69b782cfbcce7b50')],
+
+    # t_process[ndsi] recording:
+    'ndsi':
+        [('data-root/modis/tiles/h12v04/2012337/h12v04_2012337_MCD_ndsi.tif',
+          'hash',
+          'sha256',
+          '1f91f738bbb28b3ebeba36affd8d0689e105e90e1547cca58497eb7c7fdf7346'),
+         ('data-root/modis/tiles/h12v04/2012338/h12v04_2012338_MCD_ndsi.tif',
+          'hash',
+          'sha256',
+          'a626d375fbe5094a5199fdfc2206cf94777ff574379b45811cf7a49055a9f6ec'),
+         ('data-root/modis/tiles/h12v04/2012336/h12v04_2012336_MCD_ndsi.tif',
+          'hash',
+          'sha256',
+          'cb2ca7461c65f66ddb13e804ae7fe8f54daaf620ade600efee24810d40d4eb34')],
+
+    # t_process[brgt] recording:
+    'brgt':
+        [('data-root/modis/tiles/h12v04/2012338/h12v04_2012338_MCD_brgt.tif',
+          'hash',
+          'sha256',
+          'bf6bad538c7c6e703bc2f39503c2f128fa8e988a533e302c0124e085735dfaf9'),
+         ('data-root/modis/tiles/h12v04/2012337/h12v04_2012337_MCD_brgt.tif',
+          'hash',
+          'sha256',
+          '5c72e8f37640ec6b4a5a33e18980d71c70482fc8f708ba25da73e074cf64729f'),
+         ('data-root/modis/tiles/h12v04/2012336/h12v04_2012336_MCD_brgt.tif',
+          'hash',
+          'sha256',
+          '3460d0d35e35540b55e9eda35f253af8d85eabb84c0c44cb5f9c02d43da7e20a')],
+
+    # t_process[msavi2] recording:
+    'msavi2':
+        [('data-root/modis/tiles/h12v04/2012336/h12v04_2012336_MCD_msavi2.tif',
+          'hash',
+          'sha256',
+          'd2c93798df10939ff8afb6cd23e18ac3281cfd844e45da47a29d0342c2b980e9'),
+         ('data-root/modis/tiles/h12v04/2012337/h12v04_2012337_MCD_msavi2.tif',
+          'hash',
+          'sha256',
+          '92fe4f40d051ef3f479bde76a67bfff978bc513893af5ed62e4a48e457daabad'),
+         ('data-root/modis/tiles/h12v04/2012338/h12v04_2012338_MCD_msavi2.tif',
+          'hash',
+          'sha256',
+          'f25bd2d58d3edae72b11e73c08341479dee13af80352a4749861b6a54a81b351')],
+
+    # t_process[bi] recording:
+    'bi':
+        [('data-root/modis/tiles/h12v04/2012336/h12v04_2012336_MCD_bi.tif',
+          'hash',
+          'sha256',
+          '28c181b8d210b71759589da53295cc894c9d12c74ff1f7b0a49b88f73664282e'),
+         ('data-root/modis/tiles/h12v04/2012337/h12v04_2012337_MCD_bi.tif',
+          'hash',
+          'sha256',
+          '45acfc9249e063b6b97f269338590d51e2334e9bc5df118613ad908c6f0a3f8e'),
+         ('data-root/modis/tiles/h12v04/2012338/h12v04_2012338_MCD_bi.tif',
+          'hash',
+          'sha256',
+          '8526cb96d59fc9549dc8535fc8128123b9d39a63a3b7cd97ee3e611b7eeadf6f')],
+
+    # t_process[obstime] recording:
+    'obstime':
+        [('data-root/modis/tiles/h12v04/2012338/h12v04_2012338_MOD-MYD_obstime.tif',
+          'hash',
+          'sha256',
+          '66e01c94910c4fdd4f6fb2ab99b0c2d0cb73618032783e3cbdf1867191981fdc'),
+         ('data-root/modis/tiles/h12v04/2012337/h12v04_2012337_MOD-MYD_obstime.tif',
+          'hash',
+          'sha256',
+          '117cea0497b3158b465dd7dd197c886ebb1acf5059ed83dfdd6b5d7e94bb5243'),
+         ('data-root/modis/tiles/h12v04/2012336/h12v04_2012336_MOD-MYD_obstime.tif',
+          'hash',
+          'sha256',
+          'b04d8b07ef83e479db5650a30c84513bde7d5b05dd68187782c057ea0fd3e537')],
+
+    # t_process[lswi] recording:
+    'lswi':
+        [('data-root/modis/tiles/h12v04/2012336/h12v04_2012336_MCD_lswi.tif',
+          'hash',
+          'sha256',
+          '8de7378cdba830171c8da94424bf7807fa6c8b12523e8b34175a4b17ec770a5d'),
+         ('data-root/modis/tiles/h12v04/2012337/h12v04_2012337_MCD_lswi.tif',
+          'hash',
+          'sha256',
+          '62de4bdafcc276e9c1c343f4e63f5dd06167e87f7712796f991e3a957f2b71de'),
+         ('data-root/modis/tiles/h12v04/2012338/h12v04_2012338_MCD_lswi.tif',
+          'hash',
+          'sha256',
+          'add051ef35d7ffff5eb68c48f8b8071f9cb493b5d3426867605d4c61746e3a26')],
+
+    # t_process[vari] recording:
+    'vari':
+        [('data-root/modis/tiles/h12v04/2012336/h12v04_2012336_MCD_vari.tif',
+          'hash',
+          'sha256',
+          '732d6d3d9fbe0e1b4616a3f8a91bf12d532598a0a02e8aab16c9a01c3ac56913'),
+         ('data-root/modis/tiles/h12v04/2012337/h12v04_2012337_MCD_vari.tif',
+          'hash',
+          'sha256',
+          '9875717cc5e1926f11378bbf16345dbade5a2badf9f3dd06844a77f94d80ef72'),
+         ('data-root/modis/tiles/h12v04/2012338/h12v04_2012338_MCD_vari.tif',
+          'hash',
+          'sha256',
+          '70fd19862ef4145c24f26a8a74cb748279b88fd973de935726ebef2294e17edd')],
+
+    # t_process[evi] recording:
+    'evi':
+        [('data-root/modis/tiles/h12v04/2012338/h12v04_2012338_MCD_evi.tif',
+          'hash',
+          'sha256',
+          '13548ae74456f08e6add657a637ca364626eafd2cc767724f57aac8ff93005bb'),
+         ('data-root/modis/tiles/h12v04/2012337/h12v04_2012337_MCD_evi.tif',
+          'hash',
+          'sha256',
+          '7b926f7004cd92f2ec604fc4e2cc1489f60a335e39f4954030332a012fd33f87'),
+         ('data-root/modis/tiles/h12v04/2012336/h12v04_2012336_MCD_evi.tif',
+          'hash',
+          'sha256',
+          '51db813a857f795817f529edd56d7134004566be46edab8a8dadc81286fb895f')],
+
+    # t_process[clouds] recording:
+    'clouds':
+        [('data-root/modis/tiles/h12v04/2012338/h12v04_2012338_MOD_clouds.tif',
+          'hash',
+          'sha256',
+          '26b3e7e695f08ec2e9fb26985f9d5e392f9e8cedc331ab6721ea8e48821d93f0'),
+         ('data-root/modis/tiles/h12v04/2012336/h12v04_2012336_MOD_clouds.tif',
+          'hash',
+          'sha256',
+          'c43eec8178d0521d20e2a5b6e9b61525007d80702c6dd705a3e52ed3a76a7b73'),
+         ('data-root/modis/tiles/h12v04/2012337/h12v04_2012337_MOD_clouds.tif',
+          'hash',
+          'sha256',
+          '24a6a7050c866eed989530bec45b72004097f1e36fcc0e686652b87723a86de4')],
+
+    # t_process[temp] recording:
+    'temp':
+        [('data-root/modis/tiles/h12v04/2012336/h12v04_2012336_MOD-MYD_temp.tif',
+          'hash',
+          'sha256',
+          'ead2622531929bba3192b8a6b609d5d920e79394ec577c5245d74d69593d827c'),
+         ('data-root/modis/tiles/h12v04/2012337/h12v04_2012337_MOD-MYD_temp.tif',
+          'hash',
+          'sha256',
+          '5d498bad2779f84289dfb75b14345d64d16b5bc7994b4aca6cd694f70b86064d'),
+         ('data-root/modis/tiles/h12v04/2012338/h12v04_2012338_MOD-MYD_temp.tif',
+          'hash',
+          'sha256',
+          '097f341fa917a0ec316c37d7907ff15b754dcd0925469be586016137ca47575f')],
+
+    # t_process[sti] recording:
+    'sti':
+        [('data-root/modis/tiles/h12v04/2012336/h12v04_2012336_MCD_sti.tif',
+          'hash',
+          'sha256',
+          '24e50766ec18826f30bbad07bc8f5a34e72f1966b325cc23f064aa5fd35dc24a'),
+         ('data-root/modis/tiles/h12v04/2012338/h12v04_2012338_MCD_sti.tif',
+          'hash',
+          'sha256',
+          'c223de9d00e9cfedc0cfc13a45163535f3c59e5587642fa2c725b00b17b7437c'),
+         ('data-root/modis/tiles/h12v04/2012337/h12v04_2012337_MCD_sti.tif',
+          'hash',
+          'sha256',
+          '73c247fd2c7623e79145b6337846c97d14d1752d660b2f32245a4ccaac033350')],
+
+    # t_process[crc] recording:
+    'crc':
+        [('data-root/modis/tiles/h12v04/2012338/h12v04_2012338_MCD_crc.tif',
+          'hash',
+          'sha256',
+          '07debf171aedfeba7d6c1e3220ff8e4a2a7b1033e68c72bbc121b500b6ed3c9c'),
+         ('data-root/modis/tiles/h12v04/2012337/h12v04_2012337_MCD_crc.tif',
+          'hash',
+          'sha256',
+          'a7b61aabc950be7a3040b6f9572bf755522b12ad27644583e603def05ac1980b'),
+         ('data-root/modis/tiles/h12v04/2012336/h12v04_2012336_MCD_crc.tif',
+          'hash',
+          'sha256',
+          '942efeeee2b020123be6d7334bbb3ef5995c93d2fd0247cb79948836865c8067')],
 }
 
 # trailing whitespace and other junk characters are in current output

--- a/gips/test/sys/t_merra.py
+++ b/gips/test/sys/t_merra.py
@@ -43,13 +43,17 @@ def t_inventory(setup_fixture, repo_env, expected):
     actual = repo_env.run('gips_inventory', *STD_ARGS)
     assert expected == actual
 
+from .expected import merra as expectations
 
-def t_process(setup_fixture, repo_env, expected):
-    """Test gips_process on {} data.""".format(driver)
-    process_actual = repo_env.run('gips_process', *STD_ARGS)
-    inventory_actual = envoy.run('gips_inventory ' + ' '.join(STD_ARGS))
-    assert expected == process_actual
-    assert inventory_actual.std_out == expected._inv_stdout
+@pytest.mark.parametrize("product", expectations.t_process.keys())
+def t_process(setup_fixture, record_path, product):
+    """Test gips_process on merra data."""
+    dut = util.DATA_REPO_ROOT # directory under test
+
+    #process_actual = repo_env.run('gips_process', *STD_ARGS)
+    #inventory_actual = envoy.run('gips_inventory ' + ' '.join(STD_ARGS))
+    #assert expected == process_actual
+    #assert inventory_actual.std_out == expected._inv_stdout
 
 
 def t_info(repo_env, expected):

--- a/gips/test/sys/t_merra.py
+++ b/gips/test/sys/t_merra.py
@@ -1,7 +1,8 @@
 import logging
 
 import pytest
-import envoy
+import envoy # deprecated
+import sh
 
 from .util import *
 
@@ -46,15 +47,12 @@ def t_inventory(setup_fixture, repo_env, expected):
 from .expected import merra as expectations
 
 @pytest.mark.parametrize("product", expectations.t_process.keys())
-def t_process(setup_fixture, record_path, product):
+def t_process(setup_fixture, repo_wrapper, product):
     """Test gips_process on merra data."""
-    dut = util.DATA_REPO_ROOT # directory under test
-
-    #process_actual = repo_env.run('gips_process', *STD_ARGS)
-    #inventory_actual = envoy.run('gips_inventory ' + ' '.join(STD_ARGS))
-    #assert expected == process_actual
-    #assert inventory_actual.std_out == expected._inv_stdout
-
+    record_mode, expected, runner = repo_wrapper
+    outcome, actual = runner('gips_process', *(STD_ARGS + ('-p', product)))
+    if not record_mode: # don't evaluate assertions when in record-mode
+        assert outcome.exit_code == 0 and expected == actual
 
 def t_info(repo_env, expected):
     """Test `gips_info {driver}` and confirm recorded output is given."""

--- a/gips/test/sys/t_modis.py
+++ b/gips/test/sys/t_modis.py
@@ -51,19 +51,12 @@ from .expected import modis as expectations
 @pytest.mark.parametrize("product", expectations.t_process.keys())
 def t_process(setup_modis_data, repo_wrapper, product):
     """Test gips_process on modis data."""
-    (dut, record_path, expectation, expected_filenames
-     ) = repo_wrapper
-
-    args = ('modis', '-s', NH_SHP_PATH, '-d', '2012-12-01,2012-12-03',
-            '-v', '4', '-p', product)
-    print("command line: `gips_process {}`".format(' '.join(args)))
-    outcome = sh.gips_process(*args)
-
-    if not record_path:
-        # actual test: assemble data to compare to expectation
-        files = [util.generate_expectation(fn, dut)
-                    for fn in expected_filenames]
-        assert outcome.exit_code == 0 and expectation == files
+    record_mode, expected, runner = repo_wrapper
+    outcome, actual = runner('gips_process', 'modis', '-s', NH_SHP_PATH,
+                             '-d', '2012-12-01,2012-12-03', '-v', '4', '-p',
+                             product)
+    if not record_mode: # don't evaluate assertions when in record-mode
+        assert outcome.exit_code == 0 and expected == actual
 
 def t_info(repo_env, expected):
     """Test `gips_info modis` and confirm recorded output is given."""

--- a/gips/test/sys/t_modis.py
+++ b/gips/test/sys/t_modis.py
@@ -48,13 +48,10 @@ def t_inventory(setup_modis_data, repo_env, expected):
 from .expected import modis as expectations
 
 @pytest.mark.parametrize("product", expectations.t_process.keys())
-def t_process(setup_modis_data, product):
+def t_process(setup_modis_data, record_path, product):
     """Test gips_process on modis data."""
     dut = util.DATA_REPO_ROOT # directory under test
-    record_path = pytest.config.getoption('--record')
-    recording_mode = record_path is not None
-
-    if recording_mode:
+    if record_path:
         initial_files = util.find_files(dut)
     else:
         expectation = expectations.t_process[product]
@@ -70,7 +67,7 @@ def t_process(setup_modis_data, product):
     print("command line: `gips_process {}`".format(' '.join(args)))
     outcome = sh.gips_process(*args)
 
-    if recording_mode:
+    if record_path:
         final_files = find_files(dut)
         created_files = set(final_files) - set(initial_files)
 

--- a/gips/test/sys/util.py
+++ b/gips/test/sys/util.py
@@ -263,6 +263,11 @@ def generate_file_hash(filename, blocksize=2**20):
     return m.hexdigest()
 
 @pytest.yield_fixture
+def record_path(request):
+    path = pytest.config.getoption('--record')
+    return False if path in (None, '') else path
+
+@pytest.yield_fixture
 def repo_env(request):
     """Provide means to test files created by run & clean them up after."""
     if not orm.use_orm():

--- a/gips/test/unit/t_core.py
+++ b/gips/test/unit/t_core.py
@@ -11,26 +11,6 @@ from gips import core
 from gips.data.landsat.landsat import landsatRepository, landsatData
 from gips.inventory import dbinv
 
-def t_version_override(mocker):
-    """Test gips.__init__.detect_version() for correct override of __version__."""
-    env = mocker.patch.object(gips.os, 'environ')
-    # os.environ.get is called by libs as well as detect_version(); fortunately no harm seems to
-    # come from giving them bad results.
-
-    # no override requested
-    env.get.side_effect = lambda key, default=None: default # key not found
-    version_a = gips.detect_version()
-
-    # override requested
-    env.get.side_effect = lambda key, default=None: 'fancy-new-version'
-    version_b = gips.detect_version()
-
-    env.get.assert_has_calls([ # assert two identical calls
-        mock.call('GIPS_OVERRIDE_VERSION', gips.version.__version__) for _ in range(2)
-    ])
-    assert (version_a, version_b) == (gips.version.__version__, 'fancy-new-version')
-
-
 def t_repository_find_tiles_normal_case(mocker, orm):
     """Test Repository.find_tiles using landsatRepository as a guinea pig."""
     m_list_tiles = mocker.patch('gips.data.core.dbinv.list_tiles')

--- a/gips/test/unit/t_modis_fetch.py
+++ b/gips/test/unit/t_modis_fetch.py
@@ -69,7 +69,7 @@ def t_managed_request_returns_none(fetch_mocks, call, expected):
 
     # assertions
     assert expected in managed_request.call_args[0]
-    managed_request.assert_called_once()
+    assert 1 == managed_request.call_count # assert_called_once() quit working
     # It should skip the I/O code except for fetching the directory listing
     [f.assert_not_called() for f in (open, file.write)]
 


### PR DESCRIPTION
I started pulling at the seams of the existing system test framework and it seemed too well-integrated to come apart cleanly, so I had to stand up a new framework sorta in parallel to the old, mostly implemented in `util.py`.  Modis and merra's `t_process` both use the new code now.

I had to debug some general test framework issues while I was going; note pytest 3.2.5 works for this but newer versions don't due to issues mentioned in #474.

In any case, in this PR it's possible to write system tests that inspect the data repos without using scripttest.