### PR TITLE
remove level from print

### DIFF
--- a/gips/utils.py
+++ b/gips/utils.py
@@ -128,7 +128,7 @@ def vprint(*args, sep=' ', end='\n', level=1, file=sys.stdout):
     if _lib_mode:
         logging.getLogger(_named_logger).log(verbosity_to_log_level(level), sep.join(args))
     elif verbosity() >= level:
-        print(*args, sep=sep, end=end, level=level, file=file)
+        print(*args, sep=sep, end=end, file=file)
 
 
 def verbosity(new=None):


### PR DESCRIPTION
This is a super tiny thing but I get an error pointing out that 'level' is not a keyword to print. Which occurs for me in this example. But works with the one-line fix of this PR.

```
# gips_export modis -p ndvi -d 2018-100 -s s3://rob-scratch/NHseacoast.zip -v5 --fetch --res 30 30 --outdir foo --notld
Fatal: 1 error(s) occurred:
Error:
Traceback (most recent call last):
  File "/gips/gips/utils.py", line 680, in cli_error_handler
    yield
  File "/gips/gips/scripts/export.py", line 67, in run_export
    shppath = get_s3_shppath(args.site, tmpdir)
  File "/gips/gips/scripts/export.py", line 41, in get_s3_shppath
    vprint('s3path', s3path)
  File "/gips/gips/utils.py", line 131, in vprint
    print(*args, sep=sep, end=end, level=level, file=file)
TypeError: 'level' is an invalid keyword argument for this function

```
